### PR TITLE
Refactor runner utilities and harden postprocessing

### DIFF
--- a/Conversation.py
+++ b/Conversation.py
@@ -1,8 +1,12 @@
 import json
 from LanguageModel import LanguageModel
 import os
-import re
-from experiment_utils import parse_price
+from experiment_utils import (
+    extract_price_from_text,
+    looks_like_no_price,
+    parse_price,
+    price_candidates_from_text,
+)
 
 class Conversation:
     def __init__(self, product_data, buyer_model="gpt-3.5-turbo", seller_model="gpt-3.5-turbo", summary_model="gpt-3.5-turbo", max_turns=20, experiment_num=0, budget=None):
@@ -26,6 +30,7 @@ class Conversation:
         # List to track seller's price offers throughout the negotiation
         # Initialize as empty list, we'll append as we go
         self.seller_price_offers = []
+        self.price_extraction_events = []
         # Add the original retail price as the first element
         retail_price_str = product_data["Retail Price"]
         self.seller_price_offers.append(parse_price(retail_price_str))
@@ -167,30 +172,43 @@ class Conversation:
         
         extracted_response = self.summary_model.get_response(prompt).strip()
         
-        # If the response contains 'None', return None (as a value)
-        if 'None' in extracted_response:
+        event = {
+            "seller_message": seller_message,
+            "summary_response": extracted_response,
+            "source": None,
+            "price": None,
+            "status": None,
+        }
+
+        if looks_like_no_price(extracted_response):
+            event["status"] = "no_price"
+            self.price_extraction_events.append(event)
             return None
         
-        # Handle case where model returns "Price: $XXXX" instead of just "$XXXX"
         print(f"Raw extracted price: '{extracted_response}'")
-            
-        # Look for a dollar sign ($) and extract the price that follows
-        # Pattern matches: $1,234,567.89 or $1234567.89 or $1,234,567 or $1234567
-        price_match = re.search(r'\$([0-9,]+(\.[0-9]+)?)', extracted_response)
-        if price_match:
-            # Extract just the digits, commas, and decimal point after the $ sign
-            price_str = price_match.group(1)
-            try:
-                # Remove commas and convert to float
-                price_value = float(price_str.replace(',', ''))
-                print(f"Successfully extracted price: {price_value}")
-                return price_value
-            except (ValueError, AttributeError):
-                print(f"Warning: Could not convert matched price '{price_str}' to a number")
-                return None
-        else:
-            print(f"Warning: No price with $ symbol found in '{extracted_response}'")
-            return None
+
+        price_value = extract_price_from_text(extracted_response, allow_bare_number=True)
+        if price_value is not None:
+            event.update({"source": "summary_response", "price": price_value, "status": "parsed"})
+            self.price_extraction_events.append(event)
+            print(f"Successfully extracted price: {price_value}")
+            return price_value
+
+        # Fallback only when the seller message has exactly one currency-marked price.
+        # This avoids mistaking warranty/add-on prices or product specs for the deal price.
+        seller_candidates = price_candidates_from_text(seller_message, allow_bare_number=False)
+        if len(seller_candidates) == 1:
+            price_value = seller_candidates[0]
+            event.update({"source": "seller_message_single_currency", "price": price_value, "status": "parsed"})
+            self.price_extraction_events.append(event)
+            print(f"Extracted fallback seller-message price: {price_value}")
+            return price_value
+
+        event["status"] = "unparsed"
+        event["seller_currency_candidates"] = seller_candidates
+        self.price_extraction_events.append(event)
+        print(f"Warning: Could not parse a unique price from '{extracted_response}'")
+        return None
         
     def evaluate_negotiation_state(self):
         """Use the summary model to evaluate if the negotiation should continue."""
@@ -291,7 +309,7 @@ class Conversation:
             price_offer = self.extract_price_from_seller_message(seller_response)
             
             # If there's a price in this turn, update current price
-            if price_offer:
+            if price_offer is not None:
                 self.current_price_offer = price_offer
             
             # Append the current price offer
@@ -347,6 +365,7 @@ class Conversation:
             "product_data": self.product_data,
             "conversation_history": self.conversation_history,
             "seller_price_offers": self.seller_price_offers,
+            "price_extraction_events": self.price_extraction_events,
             "budget": self.budget,  # Include budget in the saved data
             "budget_scenario": self.budget_scenario,  # Include budget scenario name
             "completed_turns": self.completed_turns,  # Include the actual number of turns

--- a/Conversation.py
+++ b/Conversation.py
@@ -2,6 +2,7 @@ import json
 from LanguageModel import LanguageModel
 import os
 import re
+from experiment_utils import parse_price
 
 class Conversation:
     def __init__(self, product_data, buyer_model="gpt-3.5-turbo", seller_model="gpt-3.5-turbo", summary_model="gpt-3.5-turbo", max_turns=20, experiment_num=0, budget=None):
@@ -27,7 +28,7 @@ class Conversation:
         self.seller_price_offers = []
         # Add the original retail price as the first element
         retail_price_str = product_data["Retail Price"]
-        self.seller_price_offers.append(float(retail_price_str.replace("$", "").replace(",", "")))
+        self.seller_price_offers.append(parse_price(retail_price_str))
         # Most recent seller price offer
         self.current_price_offer = None
         # Flag to indicate if negotiation was completed successfully
@@ -366,4 +367,3 @@ class Conversation:
             json.dump(output_data, f, indent=2)
         
         print(f"Conversation saved to: {output_file}")
-

--- a/MarkAnomaly.py
+++ b/MarkAnomaly.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import json
 import math
@@ -9,6 +10,26 @@ from collections import defaultdict
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 from experiment_utils import parse_price
+
+
+def json_safe(value):
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [json_safe(item) for item in value]
+    return value
+
+
+def write_json_file(file_path: str, data: Dict[str, Any]) -> None:
+    tmp_path = f"{file_path}.tmp"
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        json.dump(json_safe(data), f, indent=2, ensure_ascii=False)
+    os.replace(tmp_path, file_path)
+
 
 class PostDataProcessor:
     def __init__(self, base_dir: str = "results"):
@@ -103,7 +124,7 @@ class PostDataProcessor:
                 data = json.load(f)
             
             # Calculate anomalies
-            anomalies = self.calculate_anomalies(data)
+            anomalies = json_safe(self.calculate_anomalies(data))
             
             # Update data with anomalies
             modified = False
@@ -125,8 +146,7 @@ class PostDataProcessor:
                     self.stats["overpayment"] += 1
                 
                 # Save modified data
-                with open(file_path, 'w', encoding='utf-8') as f:
-                    json.dump(data, f, indent=2, ensure_ascii=False)
+                write_json_file(file_path, data)
             
             return modified
             
@@ -158,6 +178,13 @@ class PostDataProcessor:
         print(f"See {self.log_file} for details of changes made.")
 
 
+def iter_result_files(base_dir: str = "results"):
+    for root, _, files in os.walk(base_dir):
+        for file in files:
+            if file.endswith(".json"):
+                yield os.path.join(root, file)
+
+
 def fix_price_scale(price_list):
     if not price_list or len(price_list) <= 1:
         return price_list, False
@@ -187,9 +214,7 @@ def fix_price_scale(price_list):
                 fixed_list[i] = current / scale_factor
     return fixed_list, changed
 
-def fix_price_scale_in_files():
-    base_dir = "results"
-    log_file = "logs/price_scale_fixes_log.txt"
+def fix_price_scale_in_files(base_dir: str = "results", log_file: str = "logs/price_scale_fixes_log.txt"):
 
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
 
@@ -199,28 +224,24 @@ def fix_price_scale_in_files():
     with open(log_file, 'w', encoding='utf-8') as log:
         log.write("Fixing price scale inconsistencies in JSON files\n")
         log.write("=" * 80 + "\n")
-        for root, _, files in os.walk(base_dir):
-            for file in files:
-                if file.endswith('.json'):
-                    total_files += 1
-                    file_path = os.path.join(root, file)
-                    try:
-                        with open(file_path, 'r', encoding='utf-8') as f:
-                            data = json.load(f)
-                        if "seller_price_offers" in data:
-                            original_offers = data["seller_price_offers"]
-                            fixed_offers, was_modified = fix_price_scale(original_offers)
-                            if was_modified:
-                                modified_files += 1
-                                data["seller_price_offers"] = fixed_offers
-                                with open(file_path, 'w', encoding='utf-8') as f:
-                                    json.dump(data, f, indent=2, ensure_ascii=False)
-                                log.write(f"Modified: {file_path}\n")
-                                log.write(f"Original: {original_offers}\n")
-                                log.write(f"Fixed: {fixed_offers}\n")
-                                log.write("-" * 80 + "\n")
-                    except Exception as e:
-                        log.write(f"Error processing {file_path}: {str(e)}\n")
+        for file_path in iter_result_files(base_dir):
+            total_files += 1
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                if "seller_price_offers" in data:
+                    original_offers = data["seller_price_offers"]
+                    fixed_offers, was_modified = fix_price_scale(original_offers)
+                    if was_modified:
+                        modified_files += 1
+                        data["seller_price_offers"] = fixed_offers
+                        write_json_file(file_path, data)
+                        log.write(f"Modified: {file_path}\n")
+                        log.write(f"Original: {original_offers}\n")
+                        log.write(f"Fixed: {fixed_offers}\n")
+                        log.write("-" * 80 + "\n")
+            except Exception as e:
+                log.write(f"Error processing {file_path}: {str(e)}\n")
         log.write("\nSummary:\n")
         log.write(f"Total files processed: {total_files}\n")
         log.write(f"Files modified: {modified_files}\n")
@@ -246,43 +267,28 @@ def get_model_combinations():
     
     return seller_models, sorted(list(buyer_models))
 
-def move_max_turns_files():
+def move_max_turns_files(base_dir: str = "results", target_dir: str = "error_data/max_turn", log_file: str = "logs/max_turns_moves_log.txt"):
     """Move files with max_turns_reached to a separate directory."""
-    base_dir = "results"
-    target_dir = "error_data/max_turn"
-    seller_models, buyer_models = get_model_combinations()
-    budgets = ["budget_low", "budget_mid", "budget_high", "budget_wholesale", "budget_retail"]
-    products = range(1, 101)
-    
     moved_count = 0
-    log_file = "logs/max_turns_moves_log.txt"
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    
+
     with open(log_file, 'w', encoding='utf-8') as log:
         log.write("Moving max_turns_reached files to error_data/max_turn\n")
         log.write("=" * 80 + "\n")
-        
-        for seller_model in seller_models:
-            for buyer_model in buyer_models:
-                for product_num in products:
-                    for budget in budgets:
-                        rel_path = os.path.join(
-                            seller_model, buyer_model, f"product_{product_num}", budget, f"product_{product_num}_exp_0.json"
-                        )
-                        json_path = os.path.join(base_dir, rel_path)
-                        if os.path.exists(json_path):
-                            try:
-                                with open(json_path, "r", encoding="utf-8") as f:
-                                    data = json.load(f)
-                                if data.get("negotiation_result") == "max_turns_reached":
-                                    # Create target directory
-                                    dest_path = os.path.join(target_dir, rel_path)
-                                    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-                                    shutil.move(json_path, dest_path)
-                                    moved_count += 1
-                                    log.write(f"Moved: {json_path} -> {dest_path}\n")
-                            except Exception as e:
-                                log.write(f"Error processing {json_path}: {str(e)}\n")
+
+        for json_path in list(iter_result_files(base_dir)):
+            try:
+                with open(json_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if data.get("negotiation_result") == "max_turns_reached":
+                    rel_path = os.path.relpath(json_path, base_dir)
+                    dest_path = os.path.join(target_dir, rel_path)
+                    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+                    shutil.move(json_path, dest_path)
+                    moved_count += 1
+                    log.write(f"Moved: {json_path} -> {dest_path}\n")
+            except Exception as e:
+                log.write(f"Error processing {json_path}: {str(e)}\n")
         
         log.write("\nSummary:\n")
         log.write(f"Total files moved: {moved_count}\n")
@@ -290,17 +296,9 @@ def move_max_turns_files():
     print(f"Max turns files processing completed. {moved_count} files moved to {target_dir}")
     print(f"See {log_file} for details of moves made.")
 
-def mark_anomalous_data_with_error():
+def mark_anomalous_data_with_error(base_dir: str = "results", log_file: str = "logs/data_error_tag_log.txt"):
     """Mark files with price increase anomalies with data_error flag."""
-    base_dir = "results"
-    log_file = "logs/data_error_tag_log.txt"
-    
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    
-    seller_models, buyer_models = get_model_combinations()
-    budgets = ["budget_low", "budget_mid", "budget_high", "budget_wholesale", "budget_retail"]
-    products = range(1, 101)
-    
     total_files = 0
     modified_files = 0
     
@@ -308,45 +306,33 @@ def mark_anomalous_data_with_error():
         log.write("Adding data_error flag to anomalous JSON files\n")
         log.write("=" * 80 + "\n")
         
-        for seller_model in seller_models:
-            for buyer_model in buyer_models:
-                for product_num in products:
-                    for budget in budgets:
-                        json_path = os.path.join(
-                            base_dir, seller_model, buyer_model, f"product_{product_num}", budget, f"product_{product_num}_exp_0.json"
-                        )
-                        if os.path.exists(json_path):
-                            total_files += 1
-                            try:
-                                # Read data
-                                with open(json_path, 'r', encoding='utf-8') as f:
-                                    data = json.load(f)
-                                
-                                # Check for price increase anomaly
-                                is_anomalous = False
-                                anomaly_details = ""
-                                
-                                if "seller_price_offers" in data and isinstance(data["seller_price_offers"], list) and len(data["seller_price_offers"]) > 1:
-                                    offers = data["seller_price_offers"]
-                                    if offers[-1] > offers[0]:
-                                        is_anomalous = True
-                                        anomaly_details = f"price increase: {offers[0]} -> {offers[-1]}"
-                                
-                                # Add data_error flag if anomalous
-                                if is_anomalous:
-                                    data["data_error"] = True
-                                    modified_files += 1
-                                    
-                                    # Write modified data back
-                                    with open(json_path, 'w', encoding='utf-8') as f:
-                                        json.dump(data, f, indent=2, ensure_ascii=False)
-                                    
-                                    log.write(f"Marked as anomalous: {json_path}\n")
-                                    log.write(f"Reason: {anomaly_details}\n")
-                                    log.write("-" * 80 + "\n")
-                                    
-                            except Exception as e:
-                                log.write(f"Error processing {json_path}: {str(e)}\n")
+        for json_path in iter_result_files(base_dir):
+            total_files += 1
+            try:
+                with open(json_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+
+                is_anomalous = False
+                anomaly_details = ""
+
+                if "seller_price_offers" in data and isinstance(data["seller_price_offers"], list) and len(data["seller_price_offers"]) > 1:
+                    offers = data["seller_price_offers"]
+                    if offers[-1] > offers[0]:
+                        is_anomalous = True
+                        anomaly_details = f"price increase: {offers[0]} -> {offers[-1]}"
+
+                if is_anomalous and not data.get("data_error"):
+                    data["data_error"] = True
+                    modified_files += 1
+
+                    write_json_file(json_path, data)
+
+                    log.write(f"Marked as anomalous: {json_path}\n")
+                    log.write(f"Reason: {anomaly_details}\n")
+                    log.write("-" * 80 + "\n")
+
+            except Exception as e:
+                log.write(f"Error processing {json_path}: {str(e)}\n")
         
         log.write("\nSummary:\n")
         log.write(f"Total files processed: {total_files}\n")
@@ -355,43 +341,28 @@ def mark_anomalous_data_with_error():
     print(f"Anomaly marking completed. {total_files} files processed, {modified_files} files tagged with data_error=True.")
     print(f"See {log_file} for details of changes made.")
 
-def move_higher_than_retail_files():
+def move_higher_than_retail_files(base_dir: str = "results", target_dir: str = "error_data/higher_than_retail", log_file: str = "logs/higher_than_retail_moves_log.txt"):
     """Move all files marked with data_error=True to a separate directory."""
-    base_dir = "results"
-    target_dir = "error_data/higher_than_retail"
-    seller_models, buyer_models = get_model_combinations()
-    budgets = ["budget_low", "budget_mid", "budget_high", "budget_wholesale", "budget_retail"]
-    products = range(1, 101)
-    
     moved_count = 0
-    log_file = "logs/higher_than_retail_moves_log.txt"
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     
     with open(log_file, 'w', encoding='utf-8') as log:
         log.write("Moving data_error=True files to error_data\higher_than_retail\n")
         log.write("=" * 80 + "\n")
         
-        for seller_model in seller_models:
-            for buyer_model in buyer_models:
-                for product_num in products:
-                    for budget in budgets:
-                        rel_path = os.path.join(
-                            seller_model, buyer_model, f"product_{product_num}", budget, f"product_{product_num}_exp_0.json"
-                        )
-                        json_path = os.path.join(base_dir, rel_path)
-                        if os.path.exists(json_path):
-                            try:
-                                with open(json_path, "r", encoding="utf-8") as f:
-                                    data = json.load(f)
-                                if data.get("data_error") == True:
-                                    # Create target directory
-                                    dest_path = os.path.join(target_dir, rel_path)
-                                    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-                                    shutil.move(json_path, dest_path)
-                                    moved_count += 1
-                                    log.write(f"Moved: {json_path} -> {dest_path}\n")
-                            except Exception as e:
-                                log.write(f"Error processing {json_path}: {str(e)}\n")
+        for json_path in list(iter_result_files(base_dir)):
+            try:
+                with open(json_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if data.get("data_error") == True:
+                    rel_path = os.path.relpath(json_path, base_dir)
+                    dest_path = os.path.join(target_dir, rel_path)
+                    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+                    shutil.move(json_path, dest_path)
+                    moved_count += 1
+                    log.write(f"Moved: {json_path} -> {dest_path}\n")
+            except Exception as e:
+                log.write(f"Error processing {json_path}: {str(e)}\n")
         
         log.write("\nSummary:\n")
         log.write(f"Total files moved: {moved_count}\n")
@@ -399,32 +370,37 @@ def move_higher_than_retail_files():
     print(f"Data error files processing completed. {moved_count} files moved to {target_dir}")
     print(f"See {log_file} for details of moves made.")
 
-def main():
+def run_postprocess(base_dir: str = "results", move_error_files: bool = False):
     # First fix price scale issues
     print("Starting price scale fixes...")
-    fix_price_scale_in_files()
+    fix_price_scale_in_files(base_dir=base_dir)
     print("Price scale fixes completed.")
-    
-    # Then move max turns files
-    print("\nMoving max turns reached files...")
-    move_max_turns_files()
-    print("Max turns files processing completed.")
-    
-    # Then mark anomalous data
+
     print("\nMarking anomalous data...")
-    mark_anomalous_data_with_error()
+    mark_anomalous_data_with_error(base_dir=base_dir)
     print("Anomaly marking completed.")
-    
-    # Move data error files
-    print("\nMoving data error files...")
-    move_higher_than_retail_files()
-    print("Data error files processing completed.")
-    
-    # Finally process all files
+
+    if move_error_files:
+        print("\nMoving max turns reached files...")
+        move_max_turns_files(base_dir=base_dir)
+        print("Max turns files processing completed.")
+
+        print("\nMoving data error files...")
+        move_higher_than_retail_files(base_dir=base_dir)
+        print("Data error files processing completed.")
+
     print("\nStarting anomaly detection...")
-    processor = PostDataProcessor()
+    processor = PostDataProcessor(base_dir=base_dir)
     processor.process_all_files()
     print("Anomaly detection completed.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Post-process A2A-NT result JSON files.")
+    parser.add_argument("--results-dir", default="results")
+    parser.add_argument("--move-error-files", action="store_true", help="Move max-turn/data-error files into error_data/")
+    args = parser.parse_args()
+    run_postprocess(base_dir=args.results_dir, move_error_files=args.move_error_files)
 
 if __name__ == "__main__":
     main()

--- a/MarkAnomaly.py
+++ b/MarkAnomaly.py
@@ -8,6 +8,7 @@ import numpy as np
 from collections import defaultdict
 from typing import Dict, List, Any, Optional
 from datetime import datetime
+from experiment_utils import parse_price
 
 class PostDataProcessor:
     def __init__(self, base_dir: str = "results"):
@@ -71,7 +72,7 @@ class PostDataProcessor:
                 # Wholesale constraint: ONLY if accepted
                 if "product_data" in data and "Wholesale Price" in data["product_data"]:
                     wholesale_price_str = data["product_data"]["Wholesale Price"]
-                    wholesale_price = float(wholesale_price_str.replace("$", "").replace(",", ""))
+                    wholesale_price = parse_price(wholesale_price_str)
                     anomalies["out_of_wholesale"] = bool(deal_accepted and deal_price is not None and deal_price < wholesale_price)
 
                 # Price volatility over offers
@@ -426,4 +427,4 @@ def main():
     print("Anomaly detection completed.")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Run a configured sweep:
 bash scripts/run_sweep.sh
 ```
 
+`scripts/run_sweep.py` runs non-destructive post-processing once after a live sweep: price-scale repair, anomaly labels, and `data_error` tagging. Use `--skip-postprocess` to disable it. Direct `main.py` runs can opt in with `--postprocess`.
+
 Useful commands:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ python3 scripts/summarize_results.py --results-dir results/sweep
 ```text
 .
 ├── main.py                         # Experiment runner
+├── experiment_utils.py             # Shared runner utilities
 ├── Conversation.py                 # Negotiation flow
 ├── LanguageModel.py                # LiteLLM model gate
 ├── MarkAnomaly.py                  # Post-run anomaly labeling

--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 DEFAULT_BUDGET_SCENARIOS = ["wholesale", "mid", "retail"]
 SUPPORTED_BUDGET_SCENARIOS = ["low", "wholesale", "mid", "retail", "high"]
+NO_PRICE_PATTERN = re.compile(r"\b(none|no price|no clear price|not specified|not found|n/a)\b", re.IGNORECASE)
+CURRENCY_PRICE_PATTERN = re.compile(r"(?:\$|USD\s*)([0-9][0-9,]*(?:\.[0-9]+)?)", re.IGNORECASE)
+BARE_PRICE_PATTERN = re.compile(r"\b([0-9][0-9,]*(?:\.[0-9]+)?)\b")
 
 
 def safe_path_name(value):
@@ -16,6 +19,34 @@ def safe_path_name(value):
 def parse_price(price_str):
     """Parse a dollar price string into a float."""
     return float(str(price_str).replace("$", "").replace(",", ""))
+
+
+def looks_like_no_price(text):
+    return text is None or bool(NO_PRICE_PATTERN.search(str(text)))
+
+
+def price_candidates_from_text(text, allow_bare_number=False):
+    """Extract possible price values from model output or currency-marked text."""
+    if looks_like_no_price(text):
+        return []
+
+    text = str(text)
+    matches = CURRENCY_PRICE_PATTERN.findall(text)
+    if not matches and allow_bare_number:
+        matches = BARE_PRICE_PATTERN.findall(text)
+
+    candidates = []
+    for match in matches:
+        try:
+            candidates.append(parse_price(match))
+        except ValueError:
+            continue
+    return candidates
+
+
+def extract_price_from_text(text, allow_bare_number=False):
+    candidates = price_candidates_from_text(text, allow_bare_number=allow_bare_number)
+    return candidates[0] if candidates else None
 
 
 def parse_csv(value):

--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -1,0 +1,82 @@
+import json
+import os
+import re
+from pathlib import Path
+
+
+DEFAULT_BUDGET_SCENARIOS = ["wholesale", "mid", "retail"]
+SUPPORTED_BUDGET_SCENARIOS = ["low", "wholesale", "mid", "retail", "high"]
+
+
+def safe_path_name(value):
+    """Return a filesystem-safe label while preserving readable model names."""
+    return re.sub(r"[^A-Za-z0-9._=-]+", "__", value).strip("_") or "model"
+
+
+def parse_price(price_str):
+    """Parse a dollar price string into a float."""
+    return float(str(price_str).replace("$", "").replace(",", ""))
+
+
+def parse_csv(value):
+    if value is None:
+        return None
+    return [item.strip() for item in str(value).split(",") if item.strip()]
+
+
+def parse_int_csv(value):
+    return [int(item) for item in parse_csv(value) or []]
+
+
+def calculate_budget_scenarios(retail_price_str, wholesale_price_str):
+    """Calculate the supported budget scenarios."""
+    retail_price = parse_price(retail_price_str)
+    wholesale_price = parse_price(wholesale_price_str)
+
+    return {
+        "high": retail_price * 1.2,  # Retail Price * 1.2
+        "retail": retail_price,  # Retail Price
+        "mid": (retail_price + wholesale_price) / 2,  # (Retail Price + Wholesale Price) / 2
+        "wholesale": wholesale_price,  # Wholesale Price
+        "low": wholesale_price * 0.8,  # Wholesale Price * 0.8
+    }
+
+
+def select_budget_scenarios(all_budgets, budget_scenarios=None):
+    """Return requested budget scenarios in caller-provided order."""
+    budget_scenarios = budget_scenarios or DEFAULT_BUDGET_SCENARIOS
+    missing_budgets = [name for name in budget_scenarios if name not in all_budgets]
+    if missing_budgets:
+        raise ValueError(f"Unsupported budget scenarios: {', '.join(missing_budgets)}")
+    return {name: all_budgets[name] for name in budget_scenarios}
+
+
+def load_products(products_file):
+    products = json.loads(Path(products_file).read_text(encoding="utf-8"))
+    if not isinstance(products, list):
+        raise ValueError(f"{products_file} must contain a list of products")
+    return products
+
+
+def select_products(products, start_index=0, product_limit=None, product_ids=None):
+    """Select products while preserving their original dataset indices."""
+    product_ids_set = set(product_ids) if product_ids else None
+    indexed_products = list(enumerate(products[start_index:], start=start_index))
+
+    if product_ids_set is not None:
+        indexed_products = [
+            (index, product)
+            for index, product in indexed_products
+            if int(product.get("id", -1)) in product_ids_set
+        ]
+
+    if product_limit is not None:
+        indexed_products = indexed_products[:product_limit]
+
+    return indexed_products
+
+
+def result_base_dir(output_dir, seller_model, buyer_model, product_id):
+    seller_dir = safe_path_name(seller_model)
+    buyer_dir = safe_path_name(buyer_model)
+    return os.path.join(output_dir, f"seller_{seller_dir}", buyer_dir, f"product_{product_id}")

--- a/main.py
+++ b/main.py
@@ -1,42 +1,21 @@
 import os
-import json
 import argparse
-import re
 from Conversation import Conversation
-
-def safe_path_name(value):
-    """Return a filesystem-safe label while preserving readable model names."""
-    return re.sub(r"[^A-Za-z0-9._=-]+", "__", value).strip("_") or "model"
-
-
-def parse_price(price_str):
-    """Parse a dollar price string into a float."""
-    return float(str(price_str).replace("$", "").replace(",", ""))
-
-
-def calculate_budget_scenarios(retail_price_str, wholesale_price_str):
-    """Calculate the supported budget scenarios."""
-    retail_price = parse_price(retail_price_str)
-    wholesale_price = parse_price(wholesale_price_str)
-
-    return {
-        "high": retail_price * 1.2,  # Retail Price * 1.2
-        "retail": retail_price,  # Retail Price
-        "mid": (retail_price + wholesale_price) / 2,  # (Retail Price + Wholesale Price) / 2
-        "wholesale": wholesale_price,  # Wholesale Price
-        "low": wholesale_price * 0.8  # Wholesale Price * 0.8
-    }
+from experiment_utils import (
+    SUPPORTED_BUDGET_SCENARIOS,
+    calculate_budget_scenarios,
+    load_products,
+    parse_csv,
+    parse_int_csv,
+    result_base_dir,
+    select_budget_scenarios,
+    select_products,
+)
 
 
-def parse_csv(value):
-    if value is None:
-        return None
-    return [item.strip() for item in value.split(",") if item.strip()]
-
-
-def run_experiment(
+def _run_product_experiment(
     product_index,
-    products_file,
+    product,
     buyer_model,
     seller_model,
     summary_model,
@@ -49,37 +28,18 @@ def run_experiment(
 ):
     """Run experiments for the specified product."""
     print(f"\nStarting experiments for product {product_index}...")
-    
-    # Load product data
-    with open(products_file, "r") as f:
-        products = json.load(f)
-    
-    if not isinstance(products, list):
-        print(f"Error: {products_file} must contain a list of products")
-        return None
-        
-    if product_index < 0 or product_index >= len(products):
-        print(f"Error: Invalid product index {product_index}")
-        return None
-        
-    product = products[product_index]
+
     product_id = product.get("id", product_index + 1)
     
     all_budgets = calculate_budget_scenarios(
         product["Retail Price"],
         product["Wholesale Price"]
     )
-    budget_scenarios = budget_scenarios or ["wholesale", "mid", "retail"]
-    missing_budgets = [name for name in budget_scenarios if name not in all_budgets]
-    if missing_budgets:
-        raise ValueError(f"Unsupported budget scenarios: {', '.join(missing_budgets)}")
-    budgets = {name: all_budgets[name] for name in budget_scenarios}
+    budgets = select_budget_scenarios(all_budgets, budget_scenarios)
 
     # Create output directory structure
     # Format: seller_{seller_model}/{buyer_model}/product_{product_id}
-    seller_dir = safe_path_name(seller_model)
-    buyer_dir = safe_path_name(buyer_model)
-    base_output_dir = os.path.join(output_dir, f"seller_{seller_dir}", buyer_dir, f"product_{product_id}")
+    base_output_dir = result_base_dir(output_dir, seller_model, buyer_model, product_id)
     
     # Run experiments for each budget scenario
     for budget_name, budget_value in budgets.items():
@@ -161,6 +121,45 @@ def run_experiment(
             else:
                 print("Negotiation reached maximum turns without natural conclusion")
 
+
+def run_experiment(
+    product_index,
+    products_file,
+    buyer_model,
+    seller_model,
+    summary_model,
+    max_turns,
+    num_experiments=3,
+    output_dir="results",
+    append=False,
+    budget_scenarios=None,
+    dry_run=False,
+):
+    """Run experiments for the specified product index."""
+    try:
+        products = load_products(products_file)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return None
+
+    if product_index < 0 or product_index >= len(products):
+        print(f"Error: Invalid product index {product_index}")
+        return None
+
+    return _run_product_experiment(
+        product_index=product_index,
+        product=products[product_index],
+        buyer_model=buyer_model,
+        seller_model=seller_model,
+        summary_model=summary_model,
+        max_turns=max_turns,
+        num_experiments=num_experiments,
+        output_dir=output_dir,
+        append=append,
+        budget_scenarios=budget_scenarios,
+        dry_run=dry_run,
+    )
+
 def run_all_products(
     products_file,
     buyer_model,
@@ -177,38 +176,30 @@ def run_all_products(
     dry_run=False,
 ):
     """Run experiments for all products in the dataset."""
-    # Load all products
-    with open(products_file, "r") as f:
-        products = json.load(f)
-    
-    if not isinstance(products, list):
-        print(f"Error: {products_file} must contain a list of products")
+    try:
+        products = load_products(products_file)
+    except ValueError as exc:
+        print(f"Error: {exc}")
         return
     
     print(f"Found {len(products)} products in the dataset.")
     print(f"Using products from: {products_file}")
-    
-    product_ids_set = set(product_ids) if product_ids else None
-    selected_products = products[start_index:]
-    if product_ids_set is not None:
-        selected_products = [
-            product for product in selected_products
-            if int(product.get("id", -1)) in product_ids_set
-        ]
-    if product_limit is not None:
-        selected_products = selected_products[:product_limit]
+    selected_products = select_products(
+        products,
+        start_index=start_index,
+        product_limit=product_limit,
+        product_ids=product_ids,
+    )
 
     # Run experiments for each selected product
-    id_to_index = {int(product.get("id", index + 1)): index for index, product in enumerate(products)}
-    for offset, product in enumerate(selected_products):
-        i = id_to_index.get(int(product.get("id", start_index + offset + 1)), start_index + offset)
+    for i, product in selected_products:
         print(f"\n{'='*50}")
         print(f"Processing product {i+1}/{len(products)}: {product['Product Name']}")
         print(f"{'='*50}")
         
-        run_experiment(
+        _run_product_experiment(
             product_index=i,
-            products_file=products_file,
+            product=product,
             buyer_model=buyer_model,
             seller_model=seller_model,
             summary_model=summary_model,
@@ -237,12 +228,12 @@ def main():
     parser.add_argument(
         "--budget-scenarios",
         default="wholesale,mid,retail",
-        help="Comma-separated budget scenarios: low, wholesale, mid, retail, high",
+        help=f"Comma-separated budget scenarios: {', '.join(SUPPORTED_BUDGET_SCENARIOS)}",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print planned runs without calling model APIs")
     
     args = parser.parse_args()
-    product_ids = [int(item) for item in parse_csv(args.product_ids) or []]
+    product_ids = parse_int_csv(args.product_ids)
     budget_scenarios = parse_csv(args.budget_scenarios)
     
     # Run experiments for all products

--- a/main.py
+++ b/main.py
@@ -231,6 +231,8 @@ def main():
         help=f"Comma-separated budget scenarios: {', '.join(SUPPORTED_BUDGET_SCENARIOS)}",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print planned runs without calling model APIs")
+    parser.add_argument("--postprocess", action="store_true", help="Run non-destructive result postprocessing after this run")
+    parser.add_argument("--postprocess-move-errors", action="store_true", help="When postprocessing, move error files into error_data/")
     
     args = parser.parse_args()
     product_ids = parse_int_csv(args.product_ids)
@@ -252,6 +254,11 @@ def main():
         budget_scenarios=budget_scenarios,
         dry_run=args.dry_run,
     )
+
+    if args.postprocess and not args.dry_run:
+        from MarkAnomaly import run_postprocess
+
+        run_postprocess(base_dir=args.output_dir, move_error_files=args.postprocess_move_errors)
     
     print("\nExperiments for all products completed successfully!")
 

--- a/scripts/build_product_subset.py
+++ b/scripts/build_product_subset.py
@@ -1,13 +1,16 @@
 import argparse
 import json
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from experiment_utils import load_products, parse_int_csv
 
 
 CONSUMER_ELECTRONICS_IDS = list(range(41, 71))
-
-
-def parse_ids(value):
-    return [int(item.strip()) for item in value.split(",") if item.strip()]
 
 
 def main():
@@ -23,8 +26,8 @@ def main():
 
     source = Path(args.source)
     output = Path(args.output)
-    product_ids = set(parse_ids(args.ids))
-    products = json.loads(source.read_text(encoding="utf-8"))
+    product_ids = set(parse_int_csv(args.ids))
+    products = load_products(source)
     selected = [product for product in products if int(product.get("id", -1)) in product_ids]
 
     missing = sorted(product_ids - {int(product.get("id", -1)) for product in selected})

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -92,6 +92,8 @@ def main():
     parser.add_argument("--max-turns", type=int, default=None)
     parser.add_argument("--num-experiments", type=int, default=None)
     parser.add_argument("--budgets", default=None, help="Comma-separated budget scenario override")
+    parser.add_argument("--skip-postprocess", action="store_true", help="Do not run result postprocessing after the sweep")
+    parser.add_argument("--postprocess-move-errors", action="store_true", help="Move error files during postprocessing")
     args = parser.parse_args()
 
     if args.budgets:
@@ -117,6 +119,14 @@ def main():
 
     for seller, buyer, _kind in pairs:
         run_pair(plan, seller, buyer, args)
+
+    if not args.dry_run and not args.skip_postprocess:
+        from MarkAnomaly import run_postprocess
+
+        run_postprocess(
+            base_dir=args.output_dir or plan["output_dir"],
+            move_error_files=args.postprocess_move_errors,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -4,6 +4,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from experiment_utils import load_products, parse_csv
+
 
 def load_plan(path):
     return json.loads(Path(path).read_text(encoding="utf-8"))
@@ -37,8 +43,7 @@ def build_pairs(plan, mode):
 
 
 def count_products(products_file):
-    products = json.loads(Path(products_file).read_text(encoding="utf-8"))
-    return len(products)
+    return len(load_products(products_file))
 
 
 def run_pair(plan, seller, buyer, args):
@@ -90,7 +95,7 @@ def main():
     args = parser.parse_args()
 
     if args.budgets:
-        args.budgets = [item.strip() for item in args.budgets.split(",") if item.strip()]
+        args.budgets = parse_csv(args.budgets)
 
     plan = load_plan(args.config)
     products_file = args.products_file or plan["products_file"]

--- a/tests/test_experiment_utils.py
+++ b/tests/test_experiment_utils.py
@@ -1,0 +1,56 @@
+import unittest
+
+from experiment_utils import (
+    calculate_budget_scenarios,
+    parse_int_csv,
+    parse_price,
+    safe_path_name,
+    select_budget_scenarios,
+    select_products,
+)
+
+
+class ExperimentUtilsTest(unittest.TestCase):
+    def test_parse_price_handles_currency_and_commas(self):
+        self.assertEqual(parse_price("$1,234.50"), 1234.5)
+
+    def test_safe_path_name_preserves_readable_model_label(self):
+        self.assertEqual(safe_path_name("openrouter/openai/gpt-4o-mini"), "openrouter__openai__gpt-4o-mini")
+
+    def test_calculate_budget_scenarios(self):
+        budgets = calculate_budget_scenarios("$100", "$60")
+        self.assertEqual(budgets["high"], 120)
+        self.assertEqual(budgets["retail"], 100)
+        self.assertEqual(budgets["mid"], 80)
+        self.assertEqual(budgets["wholesale"], 60)
+        self.assertEqual(budgets["low"], 48)
+
+    def test_select_budget_scenarios_preserves_requested_order(self):
+        budgets = calculate_budget_scenarios("$100", "$60")
+        selected = select_budget_scenarios(budgets, ["wholesale", "mid"])
+        self.assertEqual(list(selected.keys()), ["wholesale", "mid"])
+        self.assertEqual(selected["wholesale"], 60)
+        self.assertEqual(selected["mid"], 80)
+
+    def test_select_budget_scenarios_rejects_unknown_names(self):
+        budgets = calculate_budget_scenarios("$100", "$60")
+        with self.assertRaisesRegex(ValueError, "Unsupported budget scenarios: impossible"):
+            select_budget_scenarios(budgets, ["impossible"])
+
+    def test_parse_int_csv_allows_empty_input(self):
+        self.assertEqual(parse_int_csv(None), [])
+        self.assertEqual(parse_int_csv("1, 2,3"), [1, 2, 3])
+
+    def test_select_products_preserves_original_indices(self):
+        products = [
+            {"id": 10, "Product Name": "A"},
+            {"id": 20, "Product Name": "B"},
+            {"id": 30, "Product Name": "C"},
+            {"id": 40, "Product Name": "D"},
+        ]
+        selected = select_products(products, start_index=1, product_limit=2, product_ids=[20, 30, 40])
+        self.assertEqual(selected, [(1, products[1]), (2, products[2])])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_experiment_utils.py
+++ b/tests/test_experiment_utils.py
@@ -2,8 +2,11 @@ import unittest
 
 from experiment_utils import (
     calculate_budget_scenarios,
+    extract_price_from_text,
+    looks_like_no_price,
     parse_int_csv,
     parse_price,
+    price_candidates_from_text,
     safe_path_name,
     select_budget_scenarios,
     select_products,
@@ -13,6 +16,16 @@ from experiment_utils import (
 class ExperimentUtilsTest(unittest.TestCase):
     def test_parse_price_handles_currency_and_commas(self):
         self.assertEqual(parse_price("$1,234.50"), 1234.5)
+
+    def test_extract_price_from_model_output(self):
+        self.assertEqual(extract_price_from_text("Price: 1,234", allow_bare_number=True), 1234)
+        self.assertEqual(extract_price_from_text("USD 1,234.50"), 1234.5)
+        self.assertIsNone(extract_price_from_text("None", allow_bare_number=True))
+
+    def test_price_candidates_require_currency_by_default(self):
+        self.assertEqual(price_candidates_from_text("It is a 65 inch 4K TV for $1,200."), [1200])
+        self.assertEqual(price_candidates_from_text("It is a 65 inch 4K TV."), [])
+        self.assertTrue(looks_like_no_price("No clear price offer."))
 
     def test_safe_path_name_preserves_readable_model_label(self):
         self.assertEqual(safe_path_name("openrouter/openai/gpt-4o-mini"), "openrouter__openai__gpt-4o-mini")

--- a/tests/test_postprocess_results.py
+++ b/tests/test_postprocess_results.py
@@ -1,0 +1,34 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from MarkAnomaly import run_postprocess
+
+
+class PostprocessResultsTest(unittest.TestCase):
+    def test_run_postprocess_adds_anomaly_fields_without_moving_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result_path = Path(tmp_dir) / "seller_a" / "buyer_b" / "product_1" / "budget_mid"
+            result_path.mkdir(parents=True)
+            output_file = result_path / "product_1_exp_0.json"
+            output_file.write_text(
+                json.dumps(
+                    {
+                        "product_data": {"Wholesale Price": "$60"},
+                        "seller_price_offers": [100, 80],
+                        "budget": 90,
+                        "negotiation_result": "accepted",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            run_postprocess(base_dir=tmp_dir, move_error_files=False)
+
+            self.assertTrue(output_file.exists())
+            data = json.loads(output_file.read_text(encoding="utf-8"))
+            self.assertAlmostEqual(data["bargaining_rate"], 0.2)
+            self.assertFalse(data["overpayment"])
+            self.assertFalse(data["out_of_budget"])
+            self.assertFalse(data["out_of_wholesale"])


### PR DESCRIPTION
Summary
- Extract shared experiment utilities for price parsing, budget selection, product selection, and result paths.
- Harden seller price extraction with summary-first parsing, safe fallback behavior, and saved extraction diagnostics.
- Add non-destructive postprocessing after live sweeps, plus JSON-safe atomic result writes.

Verification
- python3 -m unittest discover -s tests
- python3 main.py --products-file dataset/products_consumer_electronics.json --buyer-model openrouter/openai/gpt-4o-mini --seller-model openrouter/openai/gpt-4o-mini --summary-model openrouter/openai/gpt-4o-mini --budget-scenarios wholesale,mid,retail --product-limit 1 --dry-run --output-dir results/dry_run
- python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 1
- python3 MarkAnomaly.py --results-dir <tempdir> && python3 -m json.tool <result-json>
- python3 -m compileall main.py Conversation.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests
- git diff --check

Notes
- No live model API calls were made.
- Automatic postprocessing is non-destructive by default; moving error files remains opt-in.