### PR TITLE
Make price-scale repair opt-in

### DIFF
--- a/MarkAnomaly.py
+++ b/MarkAnomaly.py
@@ -214,7 +214,7 @@ def fix_price_scale(price_list):
                 fixed_list[i] = current / scale_factor
     return fixed_list, changed
 
-def fix_price_scale_in_files(base_dir: str = "results", log_file: str = "logs/price_scale_fixes_log.txt"):
+def fix_price_scale_in_files(base_dir: str = "results", log_file: str = "logs/price_scale_fixes_log.txt", repair: bool = False):
 
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
 
@@ -222,7 +222,7 @@ def fix_price_scale_in_files(base_dir: str = "results", log_file: str = "logs/pr
     modified_files = 0
 
     with open(log_file, 'w', encoding='utf-8') as log:
-        log.write("Fixing price scale inconsistencies in JSON files\n")
+        log.write("Checking price scale inconsistencies in JSON files\n")
         log.write("=" * 80 + "\n")
         for file_path in iter_result_files(base_dir):
             total_files += 1
@@ -234,11 +234,17 @@ def fix_price_scale_in_files(base_dir: str = "results", log_file: str = "logs/pr
                     fixed_offers, was_modified = fix_price_scale(original_offers)
                     if was_modified:
                         modified_files += 1
-                        data["seller_price_offers"] = fixed_offers
+                        data["price_scale_warning"] = True
+                        data["price_scale_original_offers"] = original_offers
+                        data["price_scale_suggested_offers"] = fixed_offers
+                        data["price_scale_repaired"] = bool(repair)
+                        if repair:
+                            data["seller_price_offers"] = fixed_offers
                         write_json_file(file_path, data)
-                        log.write(f"Modified: {file_path}\n")
+                        log.write(f"Flagged: {file_path}\n")
                         log.write(f"Original: {original_offers}\n")
-                        log.write(f"Fixed: {fixed_offers}\n")
+                        log.write(f"Suggested: {fixed_offers}\n")
+                        log.write(f"Repaired: {repair}\n")
                         log.write("-" * 80 + "\n")
             except Exception as e:
                 log.write(f"Error processing {file_path}: {str(e)}\n")
@@ -246,7 +252,8 @@ def fix_price_scale_in_files(base_dir: str = "results", log_file: str = "logs/pr
         log.write(f"Total files processed: {total_files}\n")
         log.write(f"Files modified: {modified_files}\n")
 
-    print(f"Price scale fix completed. {total_files} files processed, {modified_files} files modified.")
+    action = "repair" if repair else "check"
+    print(f"Price scale {action} completed. {total_files} files processed, {modified_files} files flagged.")
     print(f"See {log_file} for details of changes made.")
 
 def get_model_combinations():
@@ -370,11 +377,10 @@ def move_higher_than_retail_files(base_dir: str = "results", target_dir: str = "
     print(f"Data error files processing completed. {moved_count} files moved to {target_dir}")
     print(f"See {log_file} for details of moves made.")
 
-def run_postprocess(base_dir: str = "results", move_error_files: bool = False):
-    # First fix price scale issues
-    print("Starting price scale fixes...")
-    fix_price_scale_in_files(base_dir=base_dir)
-    print("Price scale fixes completed.")
+def run_postprocess(base_dir: str = "results", move_error_files: bool = False, repair_price_scale: bool = False):
+    print("Starting price scale checks...")
+    fix_price_scale_in_files(base_dir=base_dir, repair=repair_price_scale)
+    print("Price scale checks completed.")
 
     print("\nMarking anomalous data...")
     mark_anomalous_data_with_error(base_dir=base_dir)
@@ -399,8 +405,13 @@ def main():
     parser = argparse.ArgumentParser(description="Post-process A2A-NT result JSON files.")
     parser.add_argument("--results-dir", default="results")
     parser.add_argument("--move-error-files", action="store_true", help="Move max-turn/data-error files into error_data/")
+    parser.add_argument("--repair-price-scale", action="store_true", help="Apply suggested price-scale repairs instead of only flagging them")
     args = parser.parse_args()
-    run_postprocess(base_dir=args.results_dir, move_error_files=args.move_error_files)
+    run_postprocess(
+        base_dir=args.results_dir,
+        move_error_files=args.move_error_files,
+        repair_price_scale=args.repair_price_scale,
+    )
 
 if __name__ == "__main__":
     main()

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Run a configured sweep:
 bash scripts/run_sweep.sh
 ```
 
-`scripts/run_sweep.py` runs non-destructive post-processing once after a live sweep: price-scale repair, anomaly labels, and `data_error` tagging. Use `--skip-postprocess` to disable it. Direct `main.py` runs can opt in with `--postprocess`.
+`scripts/run_sweep.py` runs non-destructive post-processing once after a live sweep: price-scale warnings, anomaly labels, and `data_error` tagging. Use `--skip-postprocess` to disable it. Direct `main.py` runs can opt in with `--postprocess`. Price-scale repair is opt-in with `--repair-price-scale`; by default suspicious scales are flagged but original offers are preserved.
 
 Useful commands:
 

--- a/main.py
+++ b/main.py
@@ -233,6 +233,7 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="Print planned runs without calling model APIs")
     parser.add_argument("--postprocess", action="store_true", help="Run non-destructive result postprocessing after this run")
     parser.add_argument("--postprocess-move-errors", action="store_true", help="When postprocessing, move error files into error_data/")
+    parser.add_argument("--repair-price-scale", action="store_true", help="When postprocessing, apply price-scale repair suggestions")
     
     args = parser.parse_args()
     product_ids = parse_int_csv(args.product_ids)
@@ -258,7 +259,11 @@ def main():
     if args.postprocess and not args.dry_run:
         from MarkAnomaly import run_postprocess
 
-        run_postprocess(base_dir=args.output_dir, move_error_files=args.postprocess_move_errors)
+        run_postprocess(
+            base_dir=args.output_dir,
+            move_error_files=args.postprocess_move_errors,
+            repair_price_scale=args.repair_price_scale,
+        )
     
     print("\nExperiments for all products completed successfully!")
 

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -94,6 +94,7 @@ def main():
     parser.add_argument("--budgets", default=None, help="Comma-separated budget scenario override")
     parser.add_argument("--skip-postprocess", action="store_true", help="Do not run result postprocessing after the sweep")
     parser.add_argument("--postprocess-move-errors", action="store_true", help="Move error files during postprocessing")
+    parser.add_argument("--repair-price-scale", action="store_true", help="Apply price-scale repair suggestions during postprocessing")
     args = parser.parse_args()
 
     if args.budgets:
@@ -126,6 +127,7 @@ def main():
         run_postprocess(
             base_dir=args.output_dir or plan["output_dir"],
             move_error_files=args.postprocess_move_errors,
+            repair_price_scale=args.repair_price_scale,
         )
 
 

--- a/tests/test_postprocess_results.py
+++ b/tests/test_postprocess_results.py
@@ -32,3 +32,52 @@ class PostprocessResultsTest(unittest.TestCase):
             self.assertFalse(data["overpayment"])
             self.assertFalse(data["out_of_budget"])
             self.assertFalse(data["out_of_wholesale"])
+
+    def test_postprocess_flags_price_scale_without_repair_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result_path = Path(tmp_dir) / "seller_a" / "buyer_b" / "product_1" / "budget_mid"
+            result_path.mkdir(parents=True)
+            output_file = result_path / "product_1_exp_0.json"
+            output_file.write_text(
+                json.dumps(
+                    {
+                        "product_data": {"Wholesale Price": "$60"},
+                        "seller_price_offers": [1000, 1],
+                        "budget": 90,
+                        "negotiation_result": "accepted",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            run_postprocess(base_dir=tmp_dir, move_error_files=False)
+
+            data = json.loads(output_file.read_text(encoding="utf-8"))
+            self.assertEqual(data["seller_price_offers"], [1000, 1])
+            self.assertTrue(data["price_scale_warning"])
+            self.assertFalse(data["price_scale_repaired"])
+            self.assertEqual(data["price_scale_suggested_offers"], [1000, 1000])
+
+    def test_postprocess_repairs_price_scale_when_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result_path = Path(tmp_dir) / "seller_a" / "buyer_b" / "product_1" / "budget_mid"
+            result_path.mkdir(parents=True)
+            output_file = result_path / "product_1_exp_0.json"
+            output_file.write_text(
+                json.dumps(
+                    {
+                        "product_data": {"Wholesale Price": "$60"},
+                        "seller_price_offers": [1000, 1],
+                        "budget": 90,
+                        "negotiation_result": "accepted",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            run_postprocess(base_dir=tmp_dir, move_error_files=False, repair_price_scale=True)
+
+            data = json.loads(output_file.read_text(encoding="utf-8"))
+            self.assertEqual(data["seller_price_offers"], [1000, 1000])
+            self.assertTrue(data["price_scale_warning"])
+            self.assertTrue(data["price_scale_repaired"])


### PR DESCRIPTION
Summary
- Keep postprocess non-destructive by default for suspicious price-scale cases.
- Record price_scale_warning, original offers, suggested offers, and repaired status without changing seller_price_offers unless explicitly requested.
- Add --repair-price-scale to MarkAnomaly.py, main.py postprocess, and scripts/run_sweep.py.
- Add tests for default flag-only behavior and opt-in repair behavior.

Verification
- python3 -m unittest tests.test_postprocess_results
- python3 -m unittest discover -s tests
- python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 1
- python3 -m compileall main.py MarkAnomaly.py scripts tests
- git diff --check

Notes
- Historical results/ and local .env remain ignored and were not committed.
- Deleted stale codex branches that were merged or duplicated by web/main.