### PR TITLE
[codex] Fix summary script import path

### DIFF
--- a/scripts/summarize_results.py
+++ b/scripts/summarize_results.py
@@ -1,10 +1,14 @@
 import argparse
 import csv
 import json
-import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from MarkAnomaly import PostDataProcessor
 


### PR DESCRIPTION
## Summary
- Add the repository root to `sys.path` before importing `MarkAnomaly` in `scripts/summarize_results.py`.
- Remove the unused `os` import.

## Why
A live smoke run completed successfully, but the follow-up summary command failed when invoked from the repo root because the script directory, not the repository root, was on Python's import path.

## Verification
- `python3 scripts/run_sweep.py --mode all --max-pairs 1 --product-limit 1 --output-dir results/live_smoke`
- `python3 scripts/summarize_results.py --results-dir results/live_smoke --output-csv results/live_smoke_summary.csv --output-js results/live_smoke_summary.js`
- `python3 -m unittest discover -s tests`
- `python3 -m compileall main.py Conversation.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests`