### PR TITLE
[codex] Harden negotiation judge handling

### DIFF
--- a/Conversation.py
+++ b/Conversation.py
@@ -1,12 +1,55 @@
 import json
 from LanguageModel import LanguageModel
 import os
+import re
 from experiment_utils import (
     extract_price_from_text,
     looks_like_no_price,
     parse_price,
     price_candidates_from_text,
 )
+
+JUDGE_LABELS = {"ACCEPTANCE", "REJECTION", "CONTINUE"}
+CONDITIONAL_ACCEPTANCE_PATTERN = re.compile(
+    r"\b(only if|as long as|provided|assuming|confirm|all[- ]in|out[- ]the[- ]door|no (added |extra )?fees?)\b",
+    re.IGNORECASE,
+)
+COUNTER_OFFER_PATTERN = re.compile(
+    r"\b(would you|could you|can you|if you can|how about|meet me|come down|counter|my offer|best offer|absolute max|maximum|i can do)\b",
+    re.IGNORECASE,
+)
+
+
+def normalize_judge_label(evaluation):
+    """Normalize the summary-model state label without substring false positives."""
+    if evaluation is None:
+        return "CONTINUE", "empty_judge_response"
+
+    text = str(evaluation).strip()
+    if not text:
+        return "CONTINUE", "empty_judge_response"
+
+    first_line = text.splitlines()[0].strip().upper()
+    first_line = re.sub(r"[^A-Z_ -]", "", first_line).strip()
+    if first_line in JUDGE_LABELS:
+        return first_line, None
+
+    leading_label = re.match(r"^(ACCEPTANCE|REJECTION|CONTINUE)\b(?:\s*[-:]\s*.*)?$", first_line)
+    if leading_label:
+        return leading_label.group(1), None
+
+    return "CONTINUE", "invalid_judge_label"
+
+
+def prices_match(left, right, tolerance=0.01):
+    if left is None or right is None:
+        return False
+    return abs(float(left) - float(right)) <= tolerance
+
+
+def buyer_has_counter_offer(buyer_message):
+    return bool(COUNTER_OFFER_PATTERN.search(str(buyer_message or "")))
+
 
 class Conversation:
     def __init__(self, product_data, buyer_model="gpt-3.5-turbo", seller_model="gpt-3.5-turbo", summary_model="gpt-3.5-turbo", max_turns=20, experiment_num=0, budget=None):
@@ -31,6 +74,7 @@ class Conversation:
         # Initialize as empty list, we'll append as we go
         self.seller_price_offers = []
         self.price_extraction_events = []
+        self.judge_events = []
         # Add the original retail price as the first element
         retail_price_str = product_data["Retail Price"]
         self.seller_price_offers.append(parse_price(retail_price_str))
@@ -170,7 +214,8 @@ class Conversation:
     {seller_message}
     Price:"""
         
-        extracted_response = self.summary_model.get_response(prompt).strip()
+        raw_extracted_response = self.summary_model.get_response(prompt)
+        extracted_response = "" if raw_extracted_response is None else raw_extracted_response.strip()
         
         event = {
             "seller_message": seller_message,
@@ -179,13 +224,16 @@ class Conversation:
             "price": None,
             "status": None,
         }
+        if raw_extracted_response is None:
+            event["summary_error"] = "empty_response"
 
         if looks_like_no_price(extracted_response):
             event["status"] = "no_price"
             self.price_extraction_events.append(event)
             return None
         
-        print(f"Raw extracted price: '{extracted_response}'")
+        if extracted_response:
+            print(f"Raw extracted price: '{extracted_response}'")
 
         price_value = extract_price_from_text(extracted_response, allow_bare_number=True)
         if price_value is not None:
@@ -209,6 +257,48 @@ class Conversation:
         self.price_extraction_events.append(event)
         print(f"Warning: Could not parse a unique price from '{extracted_response}'")
         return None
+
+    def guard_judge_label(self, normalized_label, latest_buyer_message, latest_seller_message, raw_evaluation, normalize_warning=None):
+        """Apply deterministic consistency checks around the summary-model judge."""
+        buyer_prices = price_candidates_from_text(latest_buyer_message, allow_bare_number=False)
+        seller_offer = self.current_price_offer
+        guarded_label = normalized_label
+        override_reason = normalize_warning
+
+        if normalized_label == "ACCEPTANCE" and buyer_prices:
+            if seller_offer is None or not any(prices_match(price, seller_offer) for price in buyer_prices):
+                guarded_label = "CONTINUE"
+                override_reason = "buyer_price_mismatch"
+        elif normalized_label == "REJECTION" and buyer_has_counter_offer(latest_buyer_message):
+            guarded_label = "CONTINUE"
+            override_reason = "buyer_counter_offer"
+
+        conditional_acceptance = (
+            normalized_label == "ACCEPTANCE"
+            and bool(CONDITIONAL_ACCEPTANCE_PATTERN.search(str(latest_buyer_message or "")))
+        )
+        accepted_over_budget = (
+            guarded_label == "ACCEPTANCE"
+            and seller_offer is not None
+            and self.budget is not None
+            and float(seller_offer) > float(self.budget)
+        )
+
+        event = {
+            "buyer_message": latest_buyer_message,
+            "seller_message": latest_seller_message,
+            "summary_response": raw_evaluation,
+            "normalized_label": normalized_label,
+            "guarded_label": guarded_label,
+            "override_reason": override_reason,
+            "buyer_price_candidates": buyer_prices,
+            "seller_offer": seller_offer,
+            "budget": self.budget,
+            "conditional_acceptance": conditional_acceptance,
+            "accepted_over_budget": accepted_over_budget,
+        }
+        self.judge_events.append(event)
+        return guarded_label
         
     def evaluate_negotiation_state(self):
         """Use the summary model to evaluate if the negotiation should continue."""
@@ -250,14 +340,23 @@ class Conversation:
         """
         
         # Get evaluation from the summary model
-        evaluation = self.summary_model.get_response(evaluation_prompt).strip()
+        raw_evaluation = self.summary_model.get_response(evaluation_prompt)
+        evaluation = "" if raw_evaluation is None else raw_evaluation.strip()
+        normalized_label, normalize_warning = normalize_judge_label(evaluation)
+        guarded_label = self.guard_judge_label(
+            normalized_label,
+            latest_buyer_message,
+            latest_seller_message,
+            evaluation,
+            normalize_warning=normalize_warning,
+        )
         
         # Process the evaluation result
-        if "ACCEPTANCE" in evaluation:
+        if guarded_label == "ACCEPTANCE":
             self.negotiation_completed = True
             self.negotiation_result = "accepted"
             return True
-        elif "REJECTION" in evaluation:
+        elif guarded_label == "REJECTION":
             self.negotiation_completed = True
             self.negotiation_result = "rejected"
             return True
@@ -366,6 +465,7 @@ class Conversation:
             "conversation_history": self.conversation_history,
             "seller_price_offers": self.seller_price_offers,
             "price_extraction_events": self.price_extraction_events,
+            "judge_events": self.judge_events,
             "budget": self.budget,  # Include budget in the saved data
             "budget_scenario": self.budget_scenario,  # Include budget scenario name
             "completed_turns": self.completed_turns,  # Include the actual number of turns

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ results/
 
 Each result file contains the conversation history, extracted seller offers, negotiation outcome, budget scenario, and model metadata.
 
-Result files also include `price_extraction_events`, which record the summary-model extraction response, parsed price, parser source, and unparsed cases. Use these diagnostics before trusting leaderboard rows with `price_scale_warning` or `data_error`.
+Result files also include `price_extraction_events`, which record the summary-model extraction response, parsed price, parser source, and unparsed cases. They also include `judge_events`, which record the summary-model state judgment, deterministic guard output, and any override reason. Use these diagnostics before trusting leaderboard rows with `price_scale_warning` or `data_error`.
 
 Summarize a run:
 

--- a/tests/test_conversation_judge.py
+++ b/tests/test_conversation_judge.py
@@ -1,0 +1,110 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from Conversation import Conversation, normalize_judge_label
+
+
+PRODUCT = {
+    "id": 1,
+    "Product Name": "AirPods Pro 2",
+    "Retail Price": "$249",
+    "Wholesale Price": "$174",
+    "Features": "Noise cancellation and spatial audio",
+}
+
+
+class FakeSummaryModel:
+    def __init__(self, response):
+        self.response = response
+
+    def get_response(self, _prompt):
+        return self.response
+
+
+def make_conversation(summary_response="CONTINUE", budget=211.5, seller_offer=225):
+    conversation = Conversation(
+        PRODUCT,
+        buyer_model="fake-buyer",
+        seller_model="fake-seller",
+        summary_model="fake-summary",
+        budget=budget,
+    )
+    conversation.summary_model = FakeSummaryModel(summary_response)
+    conversation.current_price_offer = seller_offer
+    return conversation
+
+
+class ConversationJudgeTest(unittest.TestCase):
+    def test_normalize_judge_label_avoids_substring_false_positive(self):
+        self.assertEqual(normalize_judge_label("ACCEPTANCE"), ("ACCEPTANCE", None))
+        self.assertEqual(normalize_judge_label("not ACCEPTANCE"), ("CONTINUE", "invalid_judge_label"))
+        self.assertEqual(normalize_judge_label(None), ("CONTINUE", "empty_judge_response"))
+
+    def test_acceptance_price_mismatch_continues_negotiation(self):
+        conversation = make_conversation(summary_response="ACCEPTANCE", budget=211.5, seller_offer=225)
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "I can do $225."},
+            {"speaker": "Buyer", "message": "I can do $205 - that works for my budget and I am ready to buy."},
+        ]
+
+        completed = conversation.evaluate_negotiation_state()
+
+        self.assertFalse(completed)
+        self.assertFalse(conversation.negotiation_completed)
+        self.assertIsNone(conversation.negotiation_result)
+        self.assertEqual(conversation.judge_events[-1]["normalized_label"], "ACCEPTANCE")
+        self.assertEqual(conversation.judge_events[-1]["guarded_label"], "CONTINUE")
+        self.assertEqual(conversation.judge_events[-1]["override_reason"], "buyer_price_mismatch")
+
+    def test_matching_over_budget_acceptance_is_preserved_and_flagged(self):
+        conversation = make_conversation(summary_response="ACCEPTANCE", budget=211.5, seller_offer=225)
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "I can do $225."},
+            {"speaker": "Buyer", "message": "Deal at $225. I am ready to pay now."},
+        ]
+
+        completed = conversation.evaluate_negotiation_state()
+
+        self.assertTrue(completed)
+        self.assertEqual(conversation.negotiation_result, "accepted")
+        self.assertEqual(conversation.judge_events[-1]["guarded_label"], "ACCEPTANCE")
+        self.assertTrue(conversation.judge_events[-1]["accepted_over_budget"])
+
+    def test_rejection_with_counter_offer_continues_negotiation(self):
+        conversation = make_conversation(summary_response="REJECTION", budget=211.5, seller_offer=225)
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "I can do $225."},
+            {"speaker": "Buyer", "message": "Could you do $205? If you can meet me there, I can buy today."},
+        ]
+
+        completed = conversation.evaluate_negotiation_state()
+
+        self.assertFalse(completed)
+        self.assertEqual(conversation.judge_events[-1]["guarded_label"], "CONTINUE")
+        self.assertEqual(conversation.judge_events[-1]["override_reason"], "buyer_counter_offer")
+
+    def test_price_extraction_empty_summary_uses_single_price_fallback(self):
+        conversation = make_conversation(summary_response=None)
+
+        price = conversation.extract_price_from_seller_message("I can do $225 for a quick deal.")
+
+        self.assertEqual(price, 225)
+        self.assertEqual(conversation.price_extraction_events[-1]["source"], "seller_message_single_currency")
+
+    def test_save_conversation_includes_judge_events(self):
+        conversation = make_conversation(summary_response="ACCEPTANCE", budget=300, seller_offer=225)
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "I can do $225."},
+            {"speaker": "Buyer", "message": "Deal at $225."},
+        ]
+        conversation.evaluate_negotiation_state()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conversation.save_conversation(tmp_dir)
+            output = Path(tmp_dir) / "product_1_exp_0.json"
+            self.assertIn('"judge_events"', output.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize summary-model judge labels without substring false positives.
- Add deterministic guard logic so buyer counter-offers or mismatched buyer prices cannot be recorded as accepted deals.
- Preserve genuine over-budget acceptances as accepted outcomes while recording `accepted_over_budget` in `judge_events` for anomaly analysis.
- Record `judge_events` in result JSON and document the field in the README.
- Make price extraction tolerate empty summary-model responses by falling back to a single currency-marked seller price when safe.

## Why
The paused full sweep surfaced a case where the summary model marked a buyer counter-offer as acceptance. That can directly contaminate deal outcomes and leaderboard metrics.

## Verification
- `python3 -m unittest discover -s tests`
- `python3 -m compileall Conversation.py main.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests`
- `python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 1 --product-limit 1`
- `git diff --check`

## Notes
The existing full sweep remains paused. Existing result JSON files are not rewritten by this PR.