### PR TITLE
Harden parallel sweep execution

### DIFF
--- a/Conversation.py
+++ b/Conversation.py
@@ -1,5 +1,5 @@
 import json
-from LanguageModel import LanguageModel
+from LanguageModel import LanguageModel, ModelCallError
 import os
 import re
 from experiment_utils import (
@@ -52,14 +52,30 @@ def buyer_has_counter_offer(buyer_message):
 
 
 class Conversation:
-    def __init__(self, product_data, buyer_model="gpt-3.5-turbo", seller_model="gpt-3.5-turbo", summary_model="gpt-3.5-turbo", max_turns=20, experiment_num=0, budget=None):
+    def __init__(
+        self,
+        product_data,
+        buyer_model="gpt-3.5-turbo",
+        seller_model="gpt-3.5-turbo",
+        summary_model="gpt-3.5-turbo",
+        max_turns=20,
+        experiment_num=0,
+        budget=None,
+        judge_confirmation_model=None,
+    ):
         self.product_data = product_data
         self.buyer_model_name = buyer_model  # Store the model name
         self.seller_model_name = seller_model  # Store the model name
         self.summary_model_name = summary_model  # Store the summary model name
+        self.judge_confirmation_model_name = judge_confirmation_model
         self.buyer_model = LanguageModel(model_name=buyer_model)
         self.seller_model = LanguageModel(model_name=seller_model)
         self.summary_model = LanguageModel(model_name=summary_model)
+        self.judge_confirmation_model = (
+            LanguageModel(model_name=judge_confirmation_model)
+            if judge_confirmation_model
+            else None
+        )
         self.conversation_history = []
         self.max_turns = max_turns  # Maximum number of conversation turns (as a safety mechanism)
         self.completed_turns = 0    # Track actual number of turns completed
@@ -84,6 +100,37 @@ class Conversation:
         self.negotiation_completed = False
         # Result of the negotiation (accepted, rejected, or None if not completed)
         self.negotiation_result = None
+        self.data_error = False
+        self.error = None
+
+    def _model_error_event(self, exc, stage, role):
+        if isinstance(exc, ModelCallError):
+            payload = exc.to_dict()
+        else:
+            payload = {
+                "model": None,
+                "category": "empty_response",
+                "attempts": 0,
+                "message": str(exc),
+            }
+        payload.update({"stage": stage, "role": role})
+        return payload
+
+    def _record_data_error(self, exc, stage, role):
+        event = self._model_error_event(exc, stage=stage, role=role)
+        self.data_error = True
+        self.error = event
+        self.negotiation_completed = True
+        self.negotiation_result = "model_error"
+        return event
+
+    def _mark_summary_error(self, event, exc, stage):
+        error_event = self._model_error_event(exc, stage=stage, role="summary")
+        event["summary_error"] = error_event
+        self.data_error = True
+        if self.error is None:
+            self.error = error_event
+        return error_event
         
     def format_buyer_prompt(self):
         """Format a prompt for the buyer agent."""
@@ -214,7 +261,12 @@ class Conversation:
     {seller_message}
     Price:"""
         
-        raw_extracted_response = self.summary_model.get_response(prompt)
+        summary_error = None
+        try:
+            raw_extracted_response = self.summary_model.get_response(prompt)
+        except ModelCallError as exc:
+            summary_error = exc
+            raw_extracted_response = None
         extracted_response = "" if raw_extracted_response is None else raw_extracted_response.strip()
         
         event = {
@@ -224,8 +276,14 @@ class Conversation:
             "price": None,
             "status": None,
         }
-        if raw_extracted_response is None:
-            event["summary_error"] = "empty_response"
+        if summary_error is not None:
+            self._mark_summary_error(event, summary_error, stage="price_extraction")
+        elif raw_extracted_response is None:
+            self._mark_summary_error(
+                event,
+                ValueError("Summary model returned no price-extraction response"),
+                stage="price_extraction",
+            )
 
         if looks_like_no_price(extracted_response):
             event["status"] = "no_price"
@@ -297,8 +355,65 @@ class Conversation:
             "conditional_acceptance": conditional_acceptance,
             "accepted_over_budget": accepted_over_budget,
         }
+        if self._should_confirm_judge(event):
+            confirmed_label = self._confirm_judge_label(
+                latest_buyer_message=latest_buyer_message,
+                latest_seller_message=latest_seller_message,
+                current_label=guarded_label,
+                event=event,
+            )
+            if confirmed_label in {"REJECTION", "CONTINUE"} and guarded_label == "ACCEPTANCE":
+                guarded_label = confirmed_label
+                event["confirmation_override_reason"] = "terminal_acceptance_downgraded"
+            elif confirmed_label == "CONTINUE" and guarded_label == "REJECTION":
+                guarded_label = confirmed_label
+                event["confirmation_override_reason"] = "terminal_rejection_downgraded"
+            event["guarded_label"] = guarded_label
+
         self.judge_events.append(event)
         return guarded_label
+
+    def _should_confirm_judge(self, event):
+        if self.judge_confirmation_model is None:
+            return False
+        return bool(
+            event.get("conditional_acceptance")
+            or event.get("accepted_over_budget")
+            or event.get("override_reason")
+        )
+
+    def _confirm_judge_label(self, latest_buyer_message, latest_seller_message, current_label, event):
+        prompt = f"""
+        You are a second-pass verifier for a negotiation state classifier.
+
+        Seller's latest message: "{latest_seller_message if latest_seller_message else 'No response yet'}"
+        Buyer's latest message: "{latest_buyer_message}"
+        First-pass label after deterministic guards: {current_label}
+
+        Output exactly one of:
+        ACCEPTANCE - the buyer clearly agrees to the seller's current offer with no unresolved condition
+        REJECTION - the buyer clearly refuses or cannot proceed
+        CONTINUE - the buyer is negotiating, asking a question, making a counter-offer, or agreeing only conditionally
+
+        Strictly return a single label: ACCEPTANCE, REJECTION, or CONTINUE.
+        """
+        try:
+            raw_confirmation = self.judge_confirmation_model.get_response(prompt)
+        except ModelCallError as exc:
+            error_event = self._model_error_event(exc, stage="judge_confirmation", role="summary")
+            event["confirmation_error"] = error_event
+            self.data_error = True
+            if self.error is None:
+                self.error = error_event
+            return current_label
+
+        confirmation = "" if raw_confirmation is None else raw_confirmation.strip()
+        confirmation_label, confirmation_warning = normalize_judge_label(confirmation)
+        event["confirmation_model"] = self.judge_confirmation_model_name
+        event["confirmation_response"] = confirmation
+        event["confirmation_label"] = confirmation_label
+        event["confirmation_warning"] = confirmation_warning
+        return confirmation_label
         
     def evaluate_negotiation_state(self):
         """Use the summary model to evaluate if the negotiation should continue."""
@@ -340,9 +455,20 @@ class Conversation:
         """
         
         # Get evaluation from the summary model
-        raw_evaluation = self.summary_model.get_response(evaluation_prompt)
+        try:
+            raw_evaluation = self.summary_model.get_response(evaluation_prompt)
+        except ModelCallError as exc:
+            raw_evaluation = ""
+            summary_error = self._model_error_event(exc, stage="judge", role="summary")
+            self.data_error = True
+            if self.error is None:
+                self.error = summary_error
+        else:
+            summary_error = None
         evaluation = "" if raw_evaluation is None else raw_evaluation.strip()
         normalized_label, normalize_warning = normalize_judge_label(evaluation)
+        if summary_error is not None:
+            normalize_warning = f"summary_model_error:{summary_error['category']}"
         guarded_label = self.guard_judge_label(
             normalized_label,
             latest_buyer_message,
@@ -388,7 +514,26 @@ class Conversation:
 
         Keep the message concise and focused on opening the negotiation."""
         
-        buyer_intro = self.buyer_model.get_response(intro_prompt)
+        try:
+            buyer_intro = self.buyer_model.get_response(intro_prompt)
+        except ModelCallError as exc:
+            self.current_price_offer = self.seller_price_offers[0]
+            self.completed_turns = 0
+            self._record_data_error(exc, stage="buyer_intro", role="buyer")
+            print(f"\n[Initial] Buyer model failed: {exc.category}")
+            return self.conversation_history
+
+        if buyer_intro is None or not str(buyer_intro).strip():
+            self.current_price_offer = self.seller_price_offers[0]
+            self.completed_turns = 0
+            self._record_data_error(
+                ValueError("Buyer model returned an empty introduction"),
+                stage="buyer_intro",
+                role="buyer",
+            )
+            print("\n[Initial] Buyer model returned an empty introduction.")
+            return self.conversation_history
+
         self.conversation_history.append({"speaker": "Buyer", "message": buyer_intro})
         print(f"\n[Initial] Buyer: {buyer_intro}")
         
@@ -400,7 +545,24 @@ class Conversation:
         while turn_count <= self.max_turns:
             # Seller's turn
             seller_messages = self.format_seller_prompt()
-            seller_response = self.seller_model.get_chat_response(seller_messages)
+            try:
+                seller_response = self.seller_model.get_chat_response(seller_messages)
+            except ModelCallError as exc:
+                self.completed_turns = turn_count - 1
+                self._record_data_error(exc, stage=f"turn_{turn_count}_seller", role="seller")
+                print(f"\n[Turn {turn_count}] Seller model failed: {exc.category}")
+                break
+
+            if seller_response is None or not str(seller_response).strip():
+                self.completed_turns = turn_count - 1
+                self._record_data_error(
+                    ValueError("Seller model returned an empty response"),
+                    stage=f"turn_{turn_count}_seller",
+                    role="seller",
+                )
+                print(f"\n[Turn {turn_count}] Seller model returned an empty response.")
+                break
+
             self.conversation_history.append({"speaker": "Seller", "message": seller_response})
             print(f"\n[Turn {turn_count}] Seller: {seller_response}")
             
@@ -421,7 +583,24 @@ class Conversation:
             
             # Buyer's turn
             buyer_messages = self.format_buyer_prompt()
-            buyer_response = self.buyer_model.get_chat_response(buyer_messages)
+            try:
+                buyer_response = self.buyer_model.get_chat_response(buyer_messages)
+            except ModelCallError as exc:
+                self.completed_turns = turn_count - 1
+                self._record_data_error(exc, stage=f"turn_{turn_count}_buyer", role="buyer")
+                print(f"\n[Turn {turn_count}] Buyer model failed: {exc.category}")
+                break
+
+            if buyer_response is None or not str(buyer_response).strip():
+                self.completed_turns = turn_count - 1
+                self._record_data_error(
+                    ValueError("Buyer model returned an empty response"),
+                    stage=f"turn_{turn_count}_buyer",
+                    role="buyer",
+                )
+                print(f"\n[Turn {turn_count}] Buyer model returned an empty response.")
+                break
+
             self.conversation_history.append({"speaker": "Buyer", "message": buyer_response})
             print(f"\n[Turn {turn_count}] Buyer: {buyer_response}")
             
@@ -433,7 +612,8 @@ class Conversation:
             turn_count += 1
         
         # Record the actual number of turns completed
-        self.completed_turns = turn_count
+        if self.negotiation_result != "model_error":
+            self.completed_turns = turn_count
         
         # If we reached max_turns without completion
         if turn_count > self.max_turns and not self.negotiation_completed:
@@ -445,7 +625,10 @@ class Conversation:
         print("Negotiation process completed.")
         print(f"Turns completed: {self.completed_turns}")
         print(f"Negotiation result: {self.negotiation_result}")
-        print(f"Final price offer: ${self.current_price_offer:.2f}")
+        if self.current_price_offer is None:
+            print("Final price offer: None")
+        else:
+            print(f"Final price offer: ${self.current_price_offer:.2f}")
         
         return self.conversation_history
     
@@ -474,15 +657,22 @@ class Conversation:
             "models": {
                 "buyer": self.buyer_model_name,
                 "seller": self.seller_model_name,
-                "summary": self.summary_model_name
+                "summary": self.summary_model_name,
+                "judge_confirmation": self.judge_confirmation_model_name,
             },
             "parameters": {
                 "max_turns": self.max_turns
-            }
+            },
+            "data_error": self.data_error,
+            "error": self.error,
         }
         
-        # Save to file
-        with open(output_file, 'w') as f:
+        tmp_file = f"{output_file}.tmp.{os.getpid()}"
+        with open(tmp_file, "w", encoding="utf-8") as f:
             json.dump(output_data, f, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_file, output_file)
         
         print(f"Conversation saved to: {output_file}")

--- a/LanguageModel.py
+++ b/LanguageModel.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 _LITELLM_COMPLETION = None
 
+RETRIABLE_ERROR_CATEGORIES = {"rate_limit", "timeout", "transient", "empty_response"}
+FATAL_ERROR_CATEGORIES = {"auth", "billing_or_quota", "model_unavailable", "bad_request"}
+
 
 MODEL_ALIASES = {
     "gpt-4.1": "openrouter/openai/gpt-4.1",
@@ -91,6 +94,107 @@ def _validate_messages(messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
     return validated
 
 
+class ModelCallError(RuntimeError):
+    """Structured failure from a model provider call."""
+
+    def __init__(self, model: str, category: str, message: str, attempts: int = 0):
+        self.model = model
+        self.category = category
+        self.attempts = attempts
+        super().__init__(f"{category} error for {model} after {attempts} attempt(s): {message}")
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "model": self.model,
+            "category": self.category,
+            "attempts": self.attempts,
+            "message": str(self),
+        }
+
+
+def _status_code_from_exception(exc: Exception) -> Optional[int]:
+    for attr in ("status_code", "http_status", "status"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int):
+            return value
+    response = getattr(exc, "response", None)
+    value = getattr(response, "status_code", None)
+    return value if isinstance(value, int) else None
+
+
+def classify_model_error(exc: Exception) -> str:
+    """Classify provider failures into fatal or retriable buckets."""
+    status_code = _status_code_from_exception(exc)
+    text = f"{type(exc).__name__}: {exc}".lower()
+
+    if status_code in {401, 403} or any(
+        marker in text
+        for marker in (
+            "unauthorized",
+            "invalid api key",
+            "incorrect api key",
+            "authentication",
+            "permission denied",
+        )
+    ):
+        return "auth"
+
+    if status_code == 402 or any(
+        marker in text
+        for marker in (
+            "insufficient balance",
+            "insufficient credit",
+            "insufficient credits",
+            "quota exceeded",
+            "billing",
+            "payment required",
+            "out of credits",
+        )
+    ):
+        return "billing_or_quota"
+
+    if status_code == 404 or any(
+        marker in text
+        for marker in (
+            "model not found",
+            "not a valid model",
+            "no endpoints found",
+            "provider routing failed",
+        )
+    ):
+        return "model_unavailable"
+
+    if status_code == 400 or any(
+        marker in text
+        for marker in (
+            "bad request",
+            "invalid request",
+            "context length",
+            "maximum context",
+            "unsupported parameter",
+        )
+    ):
+        return "bad_request"
+
+    if status_code == 429 or "rate limit" in text or "too many requests" in text:
+        return "rate_limit"
+
+    if status_code in {408, 500, 502, 503, 504}:
+        return "transient"
+
+    if isinstance(exc, TimeoutError) or "timeout" in text or "timed out" in text:
+        return "timeout"
+
+    if "empty response" in text or "content is empty" in text:
+        return "empty_response"
+
+    return "transient"
+
+
+def is_retriable_model_error(category: str) -> bool:
+    return category in RETRIABLE_ERROR_CATEGORIES
+
+
 class LanguageModel:
     def __init__(self, model_name: str = "gpt-3.5-turbo"):
         self.requested_model_name = model_name
@@ -98,6 +202,8 @@ class LanguageModel:
         self._last_request_time = 0.0
         self._rate_limit_delay = float(os.getenv("A2ANT_REQUEST_DELAY_SECONDS", "1.0"))
         self._max_retries = int(os.getenv("A2ANT_MAX_RETRIES", "5"))
+        self.last_call_attempts = 0
+        self.last_error_categories = []
         self._setup_credentials()
 
     def _setup_credentials(self) -> None:
@@ -120,11 +226,14 @@ class LanguageModel:
         messages: List[Dict[str, str]],
         temperature: float = 0.7,
         max_tokens: int = 1000,
-    ) -> Optional[str]:
+    ) -> str:
         messages = _validate_messages(messages)
         retry_delay = 2.0
+        self.last_call_attempts = 0
+        self.last_error_categories = []
 
         for attempt in range(1, self._max_retries + 1):
+            self.last_call_attempts = attempt
             try:
                 self._enforce_rate_limit()
                 logger.debug("LiteLLM request model=%s messages=%s", self.model_name, json.dumps(messages))
@@ -142,25 +251,38 @@ class LanguageModel:
                     raise ValueError("LiteLLM response message content is empty")
                 return content
             except Exception as exc:
+                category = classify_model_error(exc)
+                self.last_error_categories.append(category)
                 logger.error(
-                    "LiteLLM attempt %s/%s failed for %s: %s",
+                    "LiteLLM attempt %s/%s failed for %s [%s]: %s",
                     attempt,
                     self._max_retries,
                     self.model_name,
+                    category,
                     exc,
                 )
-                if attempt == self._max_retries:
-                    return None
+                if not is_retriable_model_error(category) or attempt == self._max_retries:
+                    raise ModelCallError(
+                        model=self.model_name,
+                        category=category,
+                        message=str(exc),
+                        attempts=attempt,
+                    ) from exc
                 time.sleep(retry_delay)
                 retry_delay *= 2
-        return None
+        raise ModelCallError(
+            model=self.model_name,
+            category="transient",
+            message="Retry loop exhausted without a response",
+            attempts=self._max_retries,
+        )
 
     def get_response(
         self,
         prompt: str,
         temperature: float = 0.7,
         max_tokens: int = 1000,
-    ) -> Optional[str]:
+    ) -> str:
         return self._make_api_call(
             [{"role": "user", "content": prompt}],
             temperature=temperature,
@@ -172,5 +294,5 @@ class LanguageModel:
         messages: List[Dict[str, str]],
         temperature: float = 0.7,
         max_tokens: int = 1000,
-    ) -> Optional[str]:
+    ) -> str:
         return self._make_api_call(messages, temperature=temperature, max_tokens=max_tokens)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python3 main.py \
   --buyer-model openrouter/openai/gpt-4o-mini \
   --seller-model openrouter/openai/gpt-4o-mini \
   --summary-model openrouter/openai/gpt-4o-mini \
-  --budget-scenarios wholesale,mid,retail \
+  --budget-scenarios low,wholesale,mid,retail,high \
   --product-limit 1 \
   --dry-run
 ```
@@ -57,7 +57,7 @@ Inspect a configured sweep without calling model APIs:
 
 ```bash
 python3 scripts/validate_openrouter_models.py
-python3 scripts/run_sweep.py --dry-run
+python3 scripts/run_sweep.py --dry-run --parallel-workers 2
 ```
 
 Run a configured sweep:
@@ -71,6 +71,23 @@ Useful commands:
 ```bash
 python3 scripts/run_sweep.py --config configs/sweep_example.json --max-pairs 2 --product-limit 1 --dry-run
 python3 scripts/run_sweep.py --config configs/sweep_example.json --mode all --dry-run
+python3 scripts/run_sweep.py --config configs/sweep_example.json --mode all --parallel-workers 4 --continue-on-error
+```
+
+Live sweeps write a manifest under `logs/run_sessions/{run_id}/manifest.json`
+and per-pair logs under `logs/run_sessions/{run_id}/pairs/`. The manifest tracks
+the expected conversation cell count, completed valid JSON count, running pairs,
+failed pairs, and output directory. Resume logic counts only parseable result
+JSON files without `data_error` unless `--include-error-files` is explicitly
+provided.
+
+The primary summary model is used for seller-offer extraction and negotiation
+state judging. To compare candidate summary models on fixed price/judge fixtures:
+
+```bash
+python3 scripts/compare_summary_models.py
+python3 scripts/compare_summary_models.py --task judge --live
+python3 scripts/compare_summary_models.py --live
 ```
 
 ## Post-processing
@@ -154,6 +171,7 @@ python3 scripts/summarize_results.py --results-dir results/sweep
 │   └── products_consumer_electronics.json
 ├── scripts/
 │   ├── build_product_subset.py
+│   ├── compare_summary_models.py
 │   ├── run_sweep.py
 │   ├── summarize_results.py
 │   └── validate_openrouter_models.py

--- a/configs/sweep_example.json
+++ b/configs/sweep_example.json
@@ -5,7 +5,8 @@
   "summary_model": "openai/gpt-5.4-mini",
   "max_turns": 10,
   "num_experiments": 1,
-  "budgets": ["wholesale", "mid", "retail"],
+  "budgets": ["low", "wholesale", "mid", "retail", "high"],
+  "judge_confirmation_model": null,
   "frontier_models": [
     {
       "label": "GPT-5.5",

--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -9,6 +9,7 @@ SUPPORTED_BUDGET_SCENARIOS = ["low", "wholesale", "mid", "retail", "high"]
 NO_PRICE_PATTERN = re.compile(r"\b(none|no price|no clear price|not specified|not found|n/a)\b", re.IGNORECASE)
 CURRENCY_PRICE_PATTERN = re.compile(r"(?:\$|USD\s*)([0-9][0-9,]*(?:\.[0-9]+)?)", re.IGNORECASE)
 BARE_PRICE_PATTERN = re.compile(r"\b([0-9][0-9,]*(?:\.[0-9]+)?)\b")
+RESULT_FILENAME_PATTERN = re.compile(r"^product_(?P<product_id>\d+)_exp_(?P<experiment_num>\d+)\.json$")
 
 
 def safe_path_name(value):
@@ -111,3 +112,71 @@ def result_base_dir(output_dir, seller_model, buyer_model, product_id):
     seller_dir = safe_path_name(seller_model)
     buyer_dir = safe_path_name(buyer_model)
     return os.path.join(output_dir, f"seller_{seller_dir}", buyer_dir, f"product_{product_id}")
+
+
+def result_file_experiment_num(path):
+    match = RESULT_FILENAME_PATTERN.match(Path(path).name)
+    if not match:
+        return None
+    return int(match.group("experiment_num"))
+
+
+def iter_result_files(result_dir, product_id=None):
+    result_path = Path(result_dir)
+    if not result_path.exists():
+        return []
+
+    files = []
+    for path in result_path.rglob("product_*_exp_*.json"):
+        match = RESULT_FILENAME_PATTERN.match(path.name)
+        if not match:
+            continue
+        if product_id is not None and int(match.group("product_id")) != int(product_id):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def inspect_result_file(path, include_error_files=False):
+    """Return a compact validity record for a result JSON file."""
+    info = {
+        "path": str(path),
+        "parseable": False,
+        "valid": False,
+        "data_error": None,
+        "error": None,
+    }
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        info["error"] = str(exc)
+        return info
+
+    info["parseable"] = True
+    info["data_error"] = bool(data.get("data_error", False))
+    has_required_shape = (
+        isinstance(data.get("conversation_history"), list)
+        and "product_id" in data
+        and "experiment_num" in data
+    )
+    info["valid"] = has_required_shape and (include_error_files or not info["data_error"])
+    if not has_required_shape:
+        info["error"] = "missing_required_result_fields"
+    return info
+
+
+def count_valid_results(result_dir, product_id=None, include_error_files=False):
+    return sum(
+        1
+        for path in iter_result_files(result_dir, product_id=product_id)
+        if inspect_result_file(path, include_error_files=include_error_files)["valid"]
+    )
+
+
+def next_experiment_number(result_dir, product_id=None):
+    exp_nums = [
+        result_file_experiment_num(path)
+        for path in iter_result_files(result_dir, product_id=product_id)
+    ]
+    exp_nums = [num for num in exp_nums if num is not None]
+    return max(exp_nums) + 1 if exp_nums else 0

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
-import os
 import argparse
 from Conversation import Conversation
 from experiment_utils import (
     SUPPORTED_BUDGET_SCENARIOS,
     calculate_budget_scenarios,
+    count_valid_results,
+    iter_result_files,
     load_products,
+    next_experiment_number,
     parse_csv,
     parse_int_csv,
     result_base_dir,
@@ -25,6 +27,8 @@ def _run_product_experiment(
     append=False,
     budget_scenarios=None,
     dry_run=False,
+    include_error_files=False,
+    judge_confirmation_model=None,
 ):
     """Run experiments for the specified product."""
     print(f"\nStarting experiments for product {product_index}...")
@@ -59,28 +63,30 @@ def _run_product_experiment(
             )
             continue
         
-        # Count existing experiment files
-        existing_files = [f for f in os.listdir(full_output_dir) if f.startswith(f'product_{product_id}_exp_') and f.endswith('.json')]
-        existing_count = len(existing_files)
+        existing_files = iter_result_files(full_output_dir, product_id=product_id)
+        existing_total = len(existing_files)
+        existing_count = count_valid_results(
+            full_output_dir,
+            product_id=product_id,
+            include_error_files=include_error_files,
+        )
         
         # Check if we already have enough experiments
-        if existing_count >= num_experiments and not append:
-            print(f"\nSkipping product {product_id} with budget {budget_name} - already has {existing_count} conversations (target: {num_experiments})")
+        if existing_count >= num_experiments:
+            print(f"\nSkipping product {product_id} with budget {budget_name} - already has {existing_count} valid conversations (target: {num_experiments})")
             continue
             
         print(f"\nRunning experiments for product {product_id} with budget {budget_name}")
-        print(f"Found {existing_count} existing conversations, need {num_experiments - existing_count} more")
+        print(
+            f"Found {existing_count} valid conversations ({existing_total} JSON files), "
+            f"need {num_experiments - existing_count} more"
+        )
         
         # Calculate how many more experiments we need to run
         remaining_experiments = num_experiments - existing_count
         
-        # Find the next available experiment number
-        if append and existing_files:
-            # Extract experiment numbers from filenames like "product_1_exp_0.json"
-            exp_nums = [int(f.split('_exp_')[1].split('.')[0]) for f in existing_files]
-            start_num = max(exp_nums) + 1
-        else:
-            start_num = existing_count
+        # Always avoid overwriting parseable, invalid, or partially failed evidence files.
+        start_num = next_experiment_number(full_output_dir, product_id=product_id)
         
         # Run experiments
         for exp_num in range(remaining_experiments):
@@ -97,7 +103,8 @@ def _run_product_experiment(
                 summary_model=summary_model,
                 max_turns=max_turns,  # Used as a safety mechanism
                 experiment_num=experiment_num,
-                budget=budget_value  # Pass the budget value
+                budget=budget_value,  # Pass the budget value
+                judge_confirmation_model=judge_confirmation_model,
             )
             
             # Add budget name to the conversation object
@@ -115,9 +122,15 @@ def _run_product_experiment(
             if conversation.negotiation_completed:
                 print(f"Negotiation result: {conversation.negotiation_result}")
                 if conversation.negotiation_result == "accepted":
-                    print(f"Deal accepted at price: ${conversation.current_price_offer:.2f}")
+                    if conversation.current_price_offer is None:
+                        print("Deal accepted at price: None")
+                    else:
+                        print(f"Deal accepted at price: ${conversation.current_price_offer:.2f}")
                 elif conversation.negotiation_result == "rejected":
-                    print(f"Deal rejected. Final price offered: ${conversation.current_price_offer:.2f}")
+                    if conversation.current_price_offer is None:
+                        print("Deal rejected. Final price offered: None")
+                    else:
+                        print(f"Deal rejected. Final price offered: ${conversation.current_price_offer:.2f}")
             else:
                 print("Negotiation reached maximum turns without natural conclusion")
 
@@ -134,6 +147,8 @@ def run_experiment(
     append=False,
     budget_scenarios=None,
     dry_run=False,
+    include_error_files=False,
+    judge_confirmation_model=None,
 ):
     """Run experiments for the specified product index."""
     try:
@@ -158,6 +173,8 @@ def run_experiment(
         append=append,
         budget_scenarios=budget_scenarios,
         dry_run=dry_run,
+        include_error_files=include_error_files,
+        judge_confirmation_model=judge_confirmation_model,
     )
 
 def run_all_products(
@@ -174,6 +191,8 @@ def run_all_products(
     product_ids=None,
     budget_scenarios=None,
     dry_run=False,
+    include_error_files=False,
+    judge_confirmation_model=None,
 ):
     """Run experiments for all products in the dataset."""
     try:
@@ -209,6 +228,8 @@ def run_all_products(
             append=append,
             budget_scenarios=budget_scenarios,
             dry_run=dry_run,
+            include_error_files=include_error_files,
+            judge_confirmation_model=judge_confirmation_model,
         )
 
 def main():
@@ -218,6 +239,7 @@ def main():
     parser.add_argument("--buyer-model", default="gpt-3.5-turbo", help="Model to use for the buyer agent")
     parser.add_argument("--seller-model", default="gpt-3.5-turbo", help="Model to use for the seller agent")
     parser.add_argument("--summary-model", default="gpt-3.5-turbo", help="Model to use for extracting price offers from seller messages")
+    parser.add_argument("--judge-confirmation-model", default=None, help="Optional second-pass judge model for boundary cases")
     parser.add_argument("--max-turns", type=int, default=20, help="Maximum number of conversation turns (safety limit)")
     parser.add_argument("--output-dir", default="results", help="Directory to save results")
     parser.add_argument("--num-experiments", type=int, default=3, help="Number of experiments to run")
@@ -231,6 +253,7 @@ def main():
         help=f"Comma-separated budget scenarios: {', '.join(SUPPORTED_BUDGET_SCENARIOS)}",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print planned runs without calling model APIs")
+    parser.add_argument("--include-error-files", action="store_true", help="Count data_error result JSON files as completed when resuming")
     parser.add_argument("--postprocess", action="store_true", help="Run non-destructive result postprocessing after this run")
     parser.add_argument("--postprocess-move-errors", action="store_true", help="When postprocessing, move error files into error_data/")
     parser.add_argument("--repair-price-scale", action="store_true", help="When postprocessing, apply price-scale repair suggestions")
@@ -254,6 +277,8 @@ def main():
         product_ids=product_ids,
         budget_scenarios=budget_scenarios,
         dry_run=args.dry_run,
+        include_error_files=args.include_error_files,
+        judge_confirmation_model=args.judge_confirmation_model,
     )
 
     if args.postprocess and not args.dry_run:

--- a/scripts/compare_summary_models.py
+++ b/scripts/compare_summary_models.py
@@ -1,0 +1,373 @@
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from time import perf_counter
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from Conversation import normalize_judge_label
+from LanguageModel import LanguageModel, ModelCallError
+from experiment_utils import extract_price_from_text, looks_like_no_price, parse_csv
+
+logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+logging.getLogger("litellm").setLevel(logging.WARNING)
+
+
+PRICE_FIXTURES = [
+    {
+        "id": "single_offer_with_addon",
+        "seller_message": "I can offer the laptop for $1,099. The setup package is $49 if you want it.",
+        "expected": 1099.0,
+    },
+    {
+        "id": "no_price",
+        "seller_message": "Thanks for your interest. Tell me which features matter most to you.",
+        "expected": None,
+    },
+    {
+        "id": "usd_prefix",
+        "seller_message": "I can meet you at USD 850 for the tablet today.",
+        "expected": 850.0,
+    },
+    {
+        "id": "warranty_not_main_price",
+        "seller_message": "The phone would be $720, and an optional protection plan is $90.",
+        "expected": 720.0,
+    },
+]
+
+
+JUDGE_FIXTURES = [
+    {
+        "id": "clear_acceptance",
+        "seller_message": "I can do $225.",
+        "buyer_message": "Deal at $225. I am ready to pay now.",
+        "expected": "ACCEPTANCE",
+    },
+    {
+        "id": "counter_offer",
+        "seller_message": "I can do $225.",
+        "buyer_message": "Could you do $205? If so, I can buy today.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "clear_rejection",
+        "seller_message": "The best I can do is $225.",
+        "buyer_message": "I cannot proceed at that price.",
+        "expected": "REJECTION",
+    },
+    {
+        "id": "conditional_acceptance",
+        "seller_message": "I can do $225.",
+        "buyer_message": "That works only if delivery and tax are included.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "explicit_same_price_acceptance",
+        "seller_message": "I can sell it for $850.",
+        "buyer_message": "Yes, I can do $850. Let's move forward.",
+        "expected": "ACCEPTANCE",
+    },
+    {
+        "id": "accept_offer_without_price_repeat",
+        "seller_message": "My best offer is $1,099.",
+        "buyer_message": "That price works for me. I accept.",
+        "expected": "ACCEPTANCE",
+    },
+    {
+        "id": "okay_price_it_is",
+        "seller_message": "I can come down to $640.",
+        "buyer_message": "Okay, $640 it is.",
+        "expected": "ACCEPTANCE",
+    },
+    {
+        "id": "accept_with_payment_intent",
+        "seller_message": "I can do $720 today.",
+        "buyer_message": "I accept your $720 offer and can pay today.",
+        "expected": "ACCEPTANCE",
+    },
+    {
+        "id": "price_mismatch_counter_offer",
+        "seller_message": "I can do $900.",
+        "buyer_message": "I can buy it today for $800.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "if_you_can_counter_offer",
+        "seller_message": "The lowest I can go is $500.",
+        "buyer_message": "If you can do $450, we have a deal.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "conditional_no_extra_fees",
+        "seller_message": "I can do $1,250.",
+        "buyer_message": "I agree as long as there are no extra fees.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "conditional_shipping",
+        "seller_message": "I can do $300.",
+        "buyer_message": "Sounds good, but only if shipping is included.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "agree_word_then_counter",
+        "seller_message": "I can do $225.",
+        "buyer_message": "I agree $225 is fair, but could you do $210?",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "ask_warranty",
+        "seller_message": "I can sell it for $700.",
+        "buyer_message": "Can you tell me what warranty is included?",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "ask_best_price",
+        "seller_message": "The listed price is $999.",
+        "buyer_message": "What's your best price on this?",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "thinking_not_done",
+        "seller_message": "I can do $620.",
+        "buyer_message": "I need to think about it. Can you do any better?",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "too_expensive_counter",
+        "seller_message": "I can do $225.",
+        "buyer_message": "Thanks, but $225 is too much. If you can reach $205, I can buy.",
+        "expected": "CONTINUE",
+    },
+    {
+        "id": "explicit_pass",
+        "seller_message": "The best I can do is $780.",
+        "buyer_message": "No thanks, I will pass.",
+        "expected": "REJECTION",
+    },
+    {
+        "id": "above_budget_rejection",
+        "seller_message": "I can do $1,050.",
+        "buyer_message": "This is above my budget, so I cannot proceed.",
+        "expected": "REJECTION",
+    },
+    {
+        "id": "walk_away",
+        "seller_message": "I cannot go below $450.",
+        "buyer_message": "Unfortunately I need to walk away from this deal.",
+        "expected": "REJECTION",
+    },
+    {
+        "id": "cannot_afford",
+        "seller_message": "The final price is $1,100.",
+        "buyer_message": "I cannot afford that price.",
+        "expected": "REJECTION",
+    },
+    {
+        "id": "stop_negotiating",
+        "seller_message": "I can do $375.",
+        "buyer_message": "I don't want to continue negotiating.",
+        "expected": "REJECTION",
+    },
+]
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_price_prompt(seller_message):
+    return f"""Extract the price offered by the seller in the following message.
+Return only the numerical price (with currency symbol) if there is a clear price offer.
+If there is no clear price offer, return 'None'.
+
+IMPORTANT: Only focus on the price of the product itself. Ignore any prices for add-ons like insurance, warranty, gifts, or accessories. Only extract the current offer price for the main product.
+
+Now for the current message, please STRICTLY ONLY return the price with $ symbol, no other text:
+Seller's message:
+{seller_message}
+Price:"""
+
+
+def build_judge_prompt(buyer_message, seller_message):
+    return f"""
+You are evaluating if the buyer's latest response indicates agreement to a deal.
+
+Buyer's latest message: "{buyer_message}"
+Seller's latest message: "{seller_message}"
+
+Determine if the buyer's response indicates:
+A. ACCEPTANCE - The buyer has clearly agreed to the deal
+B. REJECTION - The buyer has clearly rejected the deal or indicated they cannot proceed
+C. CONTINUE - The buyer wants to continue negotiating
+
+Please strictly output a single line containing just one of: ACCEPTANCE, REJECTION, or CONTINUE.
+"""
+
+
+def score_price_response(response, expected):
+    text = "" if response is None else str(response).strip()
+    if expected is None:
+        return looks_like_no_price(text) or extract_price_from_text(text, allow_bare_number=True) is None
+    parsed = extract_price_from_text(text, allow_bare_number=True)
+    return parsed is not None and abs(parsed - expected) <= 0.01
+
+
+def timed_model_call(model, prompt, temperature, max_tokens):
+    started = perf_counter()
+    response = model.get_response(prompt, temperature=temperature, max_tokens=max_tokens)
+    elapsed = perf_counter() - started
+    return response, elapsed, model.last_call_attempts, list(model.last_error_categories)
+
+
+def compare_model(model_name, task="all"):
+    model = LanguageModel(model_name=model_name)
+    price_results = []
+    judge_results = []
+
+    if task in {"all", "price"}:
+        for fixture in PRICE_FIXTURES:
+            try:
+                response, elapsed, attempts, error_categories = timed_model_call(
+                    model,
+                    build_price_prompt(fixture["seller_message"]),
+                    temperature=0,
+                    max_tokens=40,
+                )
+                error = None
+            except ModelCallError as exc:
+                response = None
+                elapsed = None
+                attempts = exc.attempts
+                error_categories = list(model.last_error_categories)
+                error = exc.to_dict()
+            correct = False if error else score_price_response(response, fixture["expected"])
+            price_results.append(
+                {
+                    "id": fixture["id"],
+                    "expected": fixture["expected"],
+                    "response": response,
+                    "error": error,
+                    "correct": correct,
+                    "elapsed_seconds": elapsed,
+                    "attempts": attempts,
+                    "error_categories": error_categories,
+                }
+            )
+
+    if task in {"all", "judge"}:
+        for fixture in JUDGE_FIXTURES:
+            try:
+                response, elapsed, attempts, error_categories = timed_model_call(
+                    model,
+                    build_judge_prompt(fixture["buyer_message"], fixture["seller_message"]),
+                    temperature=0,
+                    max_tokens=20,
+                )
+                error = None
+            except ModelCallError as exc:
+                response = None
+                elapsed = None
+                attempts = exc.attempts
+                error_categories = list(model.last_error_categories)
+                error = exc.to_dict()
+            label, warning = normalize_judge_label(response)
+            correct = False if error else label == fixture["expected"]
+            judge_results.append(
+                {
+                    "id": fixture["id"],
+                    "expected": fixture["expected"],
+                    "response": response,
+                    "label": label,
+                    "warning": warning,
+                    "error": error,
+                    "correct": correct,
+                    "elapsed_seconds": elapsed,
+                    "attempts": attempts,
+                    "error_categories": error_categories,
+                }
+            )
+
+    total = len(price_results) + len(judge_results)
+    correct = sum(item["correct"] for item in price_results + judge_results)
+    judge_elapsed = [
+        item["elapsed_seconds"]
+        for item in judge_results
+        if item["elapsed_seconds"] is not None
+    ]
+    return {
+        "model": model_name,
+        "price_correct": sum(item["correct"] for item in price_results),
+        "price_total": len(price_results),
+        "judge_correct": sum(item["correct"] for item in judge_results),
+        "judge_total": len(judge_results),
+        "judge_invalid": sum(1 for item in judge_results if item.get("warning")),
+        "judge_retried": sum(1 for item in judge_results if item.get("attempts", 0) > 1),
+        "judge_avg_latency_seconds": sum(judge_elapsed) / len(judge_elapsed) if judge_elapsed else None,
+        "overall_correct": correct,
+        "overall_total": total,
+        "overall_accuracy": correct / total if total else None,
+        "price_results": price_results,
+        "judge_results": judge_results,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare candidate summary/judge models on fixed A2A-NT fixtures.")
+    parser.add_argument(
+        "--models",
+        default="openai/gpt-5.4-mini,deepseek/deepseek-v4-flash",
+        help="Comma-separated model IDs",
+    )
+    parser.add_argument("--task", choices=["all", "price", "judge"], default="all")
+    parser.add_argument("--live", action="store_true", help="Call model APIs. Omit for fixture-only dry run.")
+    parser.add_argument("--output", default=None, help="Optional JSON output path")
+    args = parser.parse_args()
+
+    models = parse_csv(args.models)
+    print(f"Models: {', '.join(models)}")
+    print(f"Task: {args.task}")
+    print(f"Fixtures: {len(PRICE_FIXTURES)} price + {len(JUDGE_FIXTURES)} judge")
+
+    if not args.live:
+        print("[dry-run] add --live to call providers")
+        return
+
+    payload = {
+        "created_at": utc_now(),
+        "models": models,
+        "task": args.task,
+        "price_fixture_count": len(PRICE_FIXTURES),
+        "judge_fixture_count": len(JUDGE_FIXTURES),
+        "results": [compare_model(model_name, task=args.task) for model_name in models],
+    }
+
+    for result in payload["results"]:
+        print(
+            f"{result['model']}: "
+            f"{result['overall_correct']}/{result['overall_total']} "
+            f"({result['overall_accuracy']:.2%}) | "
+            f"price {result['price_correct']}/{result['price_total']} | "
+            f"judge {result['judge_correct']}/{result['judge_total']} | "
+            f"judge invalid {result['judge_invalid']} | "
+            f"judge retried {result['judge_retried']}"
+        )
+
+    output = args.output
+    if output is None:
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output = f"artifacts/summary_model_compare_{stamp}.json"
+    output_path = ROOT / output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -1,14 +1,22 @@
 import argparse
+import concurrent.futures
 import json
+import os
 import subprocess
 import sys
+import threading
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from experiment_utils import load_products, parse_csv
+from experiment_utils import count_valid_results, load_products, parse_csv, safe_path_name
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat()
 
 
 def load_plan(path):
@@ -46,7 +54,7 @@ def count_products(products_file):
     return len(load_products(products_file))
 
 
-def run_pair(plan, seller, buyer, args):
+def build_pair_command(plan, seller, buyer, args):
     cmd = [
         sys.executable,
         "main.py",
@@ -68,15 +76,199 @@ def run_pair(plan, seller, buyer, args):
         args.output_dir or plan["output_dir"],
         "--append",
     ]
+    judge_confirmation_model = args.judge_confirmation_model or plan.get("judge_confirmation_model")
+    if judge_confirmation_model:
+        cmd.extend(["--judge-confirmation-model", judge_confirmation_model])
     if args.product_limit is not None:
         cmd.extend(["--product-limit", str(args.product_limit)])
+    if args.include_error_files:
+        cmd.append("--include-error-files")
     if args.dry_run:
         cmd.append("--dry-run")
+    return cmd
 
-    print(f"\n=== {seller['label']} seller vs {buyer['label']} buyer ===")
+
+def pair_id(seller, buyer, kind):
+    return (
+        f"{kind}__seller_{safe_path_name(seller['model'])}"
+        f"__buyer_{safe_path_name(buyer['model'])}"
+    )
+
+
+def write_json_atomic(path, payload):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, path)
+
+
+class SweepManifest:
+    def __init__(self, path, initial_payload):
+        self.path = Path(path)
+        self.lock = threading.Lock()
+        self.payload = dict(initial_payload)
+        self.payload.setdefault("running_pairs", {})
+        self.payload.setdefault("completed_pairs", [])
+        self.payload.setdefault("failed_pairs", [])
+        self.payload.setdefault("events", [])
+        self.write()
+
+    def write(self):
+        self.payload["updated_at"] = utc_now()
+        write_json_atomic(self.path, self.payload)
+
+    def update(self, **kwargs):
+        with self.lock:
+            self.payload.update(kwargs)
+            self.write()
+
+    def event(self, event_type, **kwargs):
+        with self.lock:
+            event = {"type": event_type, "time": utc_now()}
+            event.update(kwargs)
+            self.payload["events"].append(event)
+            self.write()
+
+    def pair_started(self, identifier, seller, buyer, kind, log_path):
+        with self.lock:
+            self.payload["running_pairs"][identifier] = {
+                "seller": seller["model"],
+                "buyer": buyer["model"],
+                "kind": kind,
+                "log_path": str(log_path),
+                "started_at": utc_now(),
+            }
+            self.write()
+
+    def pair_finished(self, identifier, result):
+        with self.lock:
+            self.payload["running_pairs"].pop(identifier, None)
+            if result["returncode"] == 0:
+                self.payload["completed_pairs"].append(result)
+            else:
+                self.payload["failed_pairs"].append(result)
+            self.payload["completed_result_json_count"] = count_valid_results(
+                self.payload["output_dir"],
+                include_error_files=False,
+            )
+            self.write()
+
+
+def run_pair(plan, seller, buyer, kind, args, manifest=None, session_dir=None):
+    cmd = build_pair_command(plan, seller, buyer, args)
+    identifier = pair_id(seller, buyer, kind)
+    log_path = None
+
+    print(f"\n=== {seller['label']} seller vs {buyer['label']} buyer ({kind}) ===")
     print(" ".join(cmd))
-    if not args.dry_run:
-        subprocess.run(cmd, check=True)
+    if args.dry_run:
+        return {"pair_id": identifier, "returncode": 0, "dry_run": True}
+
+    if session_dir is not None:
+        log_dir = Path(session_dir) / "pairs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"{identifier}.log"
+
+    if manifest is not None:
+        manifest.pair_started(identifier, seller, buyer, kind, log_path)
+
+    started_at = utc_now()
+    if log_path is None:
+        completed = subprocess.run(cmd, cwd=ROOT, check=False)
+    else:
+        with log_path.open("w", encoding="utf-8") as log_handle:
+            completed = subprocess.run(
+                cmd,
+                cwd=ROOT,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                check=False,
+                text=True,
+            )
+
+    result = {
+        "pair_id": identifier,
+        "seller": seller["model"],
+        "buyer": buyer["model"],
+        "kind": kind,
+        "returncode": completed.returncode,
+        "started_at": started_at,
+        "finished_at": utc_now(),
+        "log_path": str(log_path) if log_path else None,
+    }
+    if manifest is not None:
+        manifest.pair_finished(identifier, result)
+
+    if completed.returncode != 0 and not args.continue_on_error:
+        raise subprocess.CalledProcessError(completed.returncode, cmd)
+    return result
+
+
+def make_session(plan, args, pairs, products_file, product_count, budgets, num_experiments):
+    run_id = args.run_id or datetime.now().strftime("sweep_%Y%m%d_%H%M%S")
+    session_dir = ROOT / "logs" / "run_sessions" / run_id
+    manifest_path = Path(args.manifest_path) if args.manifest_path else session_dir / "manifest.json"
+    output_dir = args.output_dir or plan["output_dir"]
+    payload = {
+        "run_id": run_id,
+        "status": "running",
+        "created_at": utc_now(),
+        "plan_name": plan["name"],
+        "mode": args.mode,
+        "products_file": products_file,
+        "product_count": product_count,
+        "budgets": budgets,
+        "num_experiments": num_experiments,
+        "pair_count": len(pairs),
+        "expected_conversation_cells": len(pairs) * product_count * len(budgets) * num_experiments,
+        "completed_result_json_count": count_valid_results(output_dir, include_error_files=False),
+        "output_dir": output_dir,
+        "parallel_workers": args.parallel_workers,
+        "continue_on_error": args.continue_on_error,
+        "manifest_path": str(manifest_path),
+        "session_dir": str(session_dir),
+    }
+    return run_id, session_dir, SweepManifest(manifest_path, payload)
+
+
+def run_pairs(plan, pairs, args, manifest=None, session_dir=None):
+    if args.parallel_workers <= 1 or args.dry_run:
+        results = []
+        for seller, buyer, kind in pairs:
+            results.append(run_pair(plan, seller, buyer, kind, args, manifest=manifest, session_dir=session_dir))
+        return results
+
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.parallel_workers) as executor:
+        future_to_pair = {
+            executor.submit(run_pair, plan, seller, buyer, kind, args, manifest, session_dir): (seller, buyer, kind)
+            for seller, buyer, kind in pairs
+        }
+        for future in concurrent.futures.as_completed(future_to_pair):
+            try:
+                results.append(future.result())
+            except Exception as exc:
+                seller, buyer, kind = future_to_pair[future]
+                failure = {
+                    "pair_id": pair_id(seller, buyer, kind),
+                    "seller": seller["model"],
+                    "buyer": buyer["model"],
+                    "kind": kind,
+                    "returncode": None,
+                    "exception": str(exc),
+                    "finished_at": utc_now(),
+                }
+                results.append(failure)
+                if manifest is not None:
+                    manifest.event("pair_exception", **failure)
+                if not args.continue_on_error:
+                    raise
+    return results
 
 
 def main():
@@ -89,14 +281,22 @@ def main():
     parser.add_argument("--products-file", default=None)
     parser.add_argument("--output-dir", default=None)
     parser.add_argument("--summary-model", default=None)
+    parser.add_argument("--judge-confirmation-model", default=None)
     parser.add_argument("--max-turns", type=int, default=None)
     parser.add_argument("--num-experiments", type=int, default=None)
     parser.add_argument("--budgets", default=None, help="Comma-separated budget scenario override")
+    parser.add_argument("--parallel-workers", type=int, default=1, help="Number of buyer-seller pairs to run concurrently")
+    parser.add_argument("--continue-on-error", action="store_true", help="Record failed pairs and continue the sweep")
+    parser.add_argument("--include-error-files", action="store_true", help="Count data_error result JSON files as completed when resuming")
+    parser.add_argument("--run-id", default=None, help="Optional run session identifier for logs/run_sessions")
+    parser.add_argument("--manifest-path", default=None, help="Optional manifest JSON path")
     parser.add_argument("--skip-postprocess", action="store_true", help="Do not run result postprocessing after the sweep")
     parser.add_argument("--postprocess-move-errors", action="store_true", help="Move error files during postprocessing")
     parser.add_argument("--repair-price-scale", action="store_true", help="Apply price-scale repair suggestions during postprocessing")
     args = parser.parse_args()
 
+    if args.parallel_workers < 1:
+        raise ValueError("--parallel-workers must be at least 1")
     if args.budgets:
         args.budgets = parse_csv(args.budgets)
 
@@ -117,17 +317,48 @@ def main():
     print(f"Mode: {args.mode}")
     print(f"Pairs: {len(pairs)} | products: {product_count} | budgets: {len(budgets)} | experiments: {num_experiments}")
     print(f"Conversation cells: {cells}")
+    print(f"Parallel workers: {args.parallel_workers}")
 
-    for seller, buyer, _kind in pairs:
-        run_pair(plan, seller, buyer, args)
+    if args.dry_run:
+        run_pairs(plan, pairs, args)
+        return
 
-    if not args.dry_run and not args.skip_postprocess:
+    run_id, session_dir, manifest = make_session(
+        plan=plan,
+        args=args,
+        pairs=pairs,
+        products_file=products_file,
+        product_count=product_count,
+        budgets=budgets,
+        num_experiments=num_experiments,
+    )
+    print(f"Run ID: {run_id}")
+    print(f"Manifest: {manifest.path}")
+
+    try:
+        run_pairs(plan, pairs, args, manifest=manifest, session_dir=session_dir)
+        failed_pairs = manifest.payload.get("failed_pairs", [])
+        status = "completed_with_failures" if failed_pairs else "completed"
+        manifest.update(status=status)
+    except Exception:
+        manifest.update(status="failed")
+        raise
+
+    if not args.skip_postprocess:
+        manifest.update(status="postprocessing")
         from MarkAnomaly import run_postprocess
 
         run_postprocess(
             base_dir=args.output_dir or plan["output_dir"],
             move_error_files=args.postprocess_move_errors,
             repair_price_scale=args.repair_price_scale,
+        )
+        manifest.update(
+            status="completed",
+            completed_result_json_count=count_valid_results(
+                args.output_dir or plan["output_dir"],
+                include_error_files=False,
+            ),
         )
 
 

--- a/tests/test_conversation_judge.py
+++ b/tests/test_conversation_judge.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 from Conversation import Conversation, normalize_judge_label
+from LanguageModel import ModelCallError
 
 
 PRODUCT = {
@@ -20,6 +21,17 @@ class FakeSummaryModel:
 
     def get_response(self, _prompt):
         return self.response
+
+
+class FailingModel:
+    def __init__(self, category="billing_or_quota"):
+        self.category = category
+
+    def get_response(self, _prompt):
+        raise ModelCallError("fake-model", self.category, "fake failure", attempts=1)
+
+    def get_chat_response(self, _messages):
+        raise ModelCallError("fake-model", self.category, "fake failure", attempts=1)
 
 
 def make_conversation(summary_response="CONTINUE", budget=211.5, seller_offer=225):
@@ -71,6 +83,22 @@ class ConversationJudgeTest(unittest.TestCase):
         self.assertEqual(conversation.judge_events[-1]["guarded_label"], "ACCEPTANCE")
         self.assertTrue(conversation.judge_events[-1]["accepted_over_budget"])
 
+    def test_confirmation_model_can_downgrade_boundary_acceptance(self):
+        conversation = make_conversation(summary_response="ACCEPTANCE", budget=211.5, seller_offer=225)
+        conversation.judge_confirmation_model = FakeSummaryModel("CONTINUE")
+        conversation.judge_confirmation_model_name = "fake-confirmation"
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "I can do $225."},
+            {"speaker": "Buyer", "message": "Deal at $225, only if delivery is included."},
+        ]
+
+        completed = conversation.evaluate_negotiation_state()
+
+        self.assertFalse(completed)
+        self.assertEqual(conversation.judge_events[-1]["confirmation_label"], "CONTINUE")
+        self.assertEqual(conversation.judge_events[-1]["guarded_label"], "CONTINUE")
+        self.assertEqual(conversation.judge_events[-1]["confirmation_override_reason"], "terminal_acceptance_downgraded")
+
     def test_rejection_with_counter_offer_continues_negotiation(self):
         conversation = make_conversation(summary_response="REJECTION", budget=211.5, seller_offer=225)
         conversation.conversation_history = [
@@ -91,6 +119,7 @@ class ConversationJudgeTest(unittest.TestCase):
 
         self.assertEqual(price, 225)
         self.assertEqual(conversation.price_extraction_events[-1]["source"], "seller_message_single_currency")
+        self.assertTrue(conversation.data_error)
 
     def test_save_conversation_includes_judge_events(self):
         conversation = make_conversation(summary_response="ACCEPTANCE", budget=300, seller_offer=225)
@@ -104,6 +133,22 @@ class ConversationJudgeTest(unittest.TestCase):
             conversation.save_conversation(tmp_dir)
             output = Path(tmp_dir) / "product_1_exp_0.json"
             self.assertIn('"judge_events"', output.read_text(encoding="utf-8"))
+            self.assertEqual(list(Path(tmp_dir).glob("*.tmp.*")), [])
+
+    def test_buyer_intro_failure_is_saved_as_data_error(self):
+        conversation = make_conversation(summary_response="CONTINUE")
+        conversation.buyer_model = FailingModel("billing_or_quota")
+
+        conversation.run_negotiation()
+
+        self.assertTrue(conversation.data_error)
+        self.assertEqual(conversation.negotiation_result, "model_error")
+        self.assertEqual(conversation.error["role"], "buyer")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conversation.save_conversation(tmp_dir)
+            output = (Path(tmp_dir) / "product_1_exp_0.json").read_text(encoding="utf-8")
+            self.assertIn('"data_error": true', output)
 
 
 if __name__ == "__main__":

--- a/tests/test_experiment_utils.py
+++ b/tests/test_experiment_utils.py
@@ -1,8 +1,14 @@
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
 from experiment_utils import (
     calculate_budget_scenarios,
+    count_valid_results,
     extract_price_from_text,
+    inspect_result_file,
+    next_experiment_number,
     looks_like_no_price,
     parse_int_csv,
     parse_price,
@@ -63,6 +69,28 @@ class ExperimentUtilsTest(unittest.TestCase):
         ]
         selected = select_products(products, start_index=1, product_limit=2, product_ids=[20, 30, 40])
         self.assertEqual(selected, [(1, products[1]), (2, products[2])])
+
+    def test_result_validation_excludes_corrupt_and_data_error_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            valid_dir = root / "seller_a" / "buyer_b" / "product_1" / "budget_mid"
+            valid_dir.mkdir(parents=True)
+            valid_payload = {
+                "product_id": 1,
+                "experiment_num": 0,
+                "conversation_history": [],
+                "data_error": False,
+            }
+            (valid_dir / "product_1_exp_0.json").write_text(json.dumps(valid_payload), encoding="utf-8")
+
+            error_payload = dict(valid_payload, experiment_num=1, data_error=True)
+            (valid_dir / "product_1_exp_1.json").write_text(json.dumps(error_payload), encoding="utf-8")
+            (valid_dir / "product_1_exp_2.json").write_text("{bad json", encoding="utf-8")
+
+            self.assertEqual(count_valid_results(root, product_id=1), 1)
+            self.assertEqual(count_valid_results(root, product_id=1, include_error_files=True), 2)
+            self.assertEqual(next_experiment_number(valid_dir, product_id=1), 3)
+            self.assertFalse(inspect_result_file(valid_dir / "product_1_exp_2.json")["valid"])
 
 
 if __name__ == "__main__":

--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -1,0 +1,76 @@
+import unittest
+from types import SimpleNamespace
+
+import LanguageModel
+from LanguageModel import LanguageModel as ModelGate
+from LanguageModel import ModelCallError, classify_model_error
+
+
+class FakeProviderError(Exception):
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def fake_response(content):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content),
+            )
+        ]
+    )
+
+
+class LanguageModelTest(unittest.TestCase):
+    def setUp(self):
+        self._sleep = LanguageModel.time.sleep
+        LanguageModel.time.sleep = lambda _seconds: None
+
+    def tearDown(self):
+        LanguageModel._LITELLM_COMPLETION = None
+        LanguageModel.time.sleep = self._sleep
+
+    def test_classify_billing_and_auth_errors(self):
+        self.assertEqual(classify_model_error(FakeProviderError("Payment required", 402)), "billing_or_quota")
+        self.assertEqual(classify_model_error(FakeProviderError("invalid api key", 401)), "auth")
+
+    def test_fatal_provider_error_does_not_retry(self):
+        calls = []
+
+        def fail_once(**_kwargs):
+            calls.append("call")
+            raise FakeProviderError("insufficient credits", 402)
+
+        LanguageModel._LITELLM_COMPLETION = fail_once
+        model = ModelGate("local-test-model")
+        model._rate_limit_delay = 0
+        model._max_retries = 3
+
+        with self.assertRaises(ModelCallError) as ctx:
+            model.get_response("hello")
+
+        self.assertEqual(ctx.exception.category, "billing_or_quota")
+        self.assertEqual(ctx.exception.attempts, 1)
+        self.assertEqual(len(calls), 1)
+
+    def test_transient_error_retries_then_returns_content(self):
+        calls = []
+
+        def flaky(**_kwargs):
+            calls.append("call")
+            if len(calls) == 1:
+                raise TimeoutError("timed out")
+            return fake_response("ok")
+
+        LanguageModel._LITELLM_COMPLETION = flaky
+        model = ModelGate("local-test-model")
+        model._rate_limit_delay = 0
+        model._max_retries = 2
+
+        self.assertEqual(model.get_response("hello"), "ok")
+        self.assertEqual(len(calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #7

## Summary
- Added structured `ModelCallError` handling with provider error classification, retry/fail-fast behavior, and per-call attempt metadata.
- Marked failed buyer/seller calls as `data_error` result files instead of writing normal-looking corrupt conversations.
- Switched conversation saves and sweep manifests to atomic JSON writes.
- Updated resume logic to count only parseable non-`data_error` result JSON by default and avoid overwriting failed evidence files.
- Added parallel pair execution, per-pair logs, live run manifests, `--continue-on-error`, and five-budget sweep config.
- Added a reproducible summary/judge model comparison harness.

## Judge Pilot
Live judge-only pilot on 22 curated negotiation-state fixtures:
- `openai/gpt-5.4-mini`: 22/22, 0 invalid labels, 0 retries, avg latency about 1.23s.
- `deepseek/deepseek-v4-flash`: 22/22, 1 invalid/non-strict output normalized to `CONTINUE`, 4 retried calls, avg latency about 4.37s.

Recommendation: use `openai/gpt-5.4-mini` as the primary judge for reliability. DeepSeek V4 Flash remains a low-cost fallback candidate, but the pilot showed more provider instability and one non-strict judge response.

## Verification
- `python3 -m unittest discover -s tests`
- `python3 -m compileall Conversation.py main.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests`
- `python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 1 --product-limit 1 --parallel-workers 2`
- `python3 scripts/compare_summary_models.py --task judge`
- Live pilot: `python3 scripts/compare_summary_models.py --task judge --live`

## Notes
- No existing paused experiment was resumed.
- Generated artifacts/logs/results were not committed.
