### PR TITLE
Fix parallel pilot runner regression

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 from Conversation import Conversation
 from experiment_utils import (
     SUPPORTED_BUDGET_SCENARIOS,

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -338,8 +338,8 @@ def main():
     try:
         run_pairs(plan, pairs, args, manifest=manifest, session_dir=session_dir)
         failed_pairs = manifest.payload.get("failed_pairs", [])
-        status = "completed_with_failures" if failed_pairs else "completed"
-        manifest.update(status=status)
+        final_status = "completed_with_failures" if failed_pairs else "completed"
+        manifest.update(status=final_status)
     except Exception:
         manifest.update(status="failed")
         raise
@@ -354,7 +354,7 @@ def main():
             repair_price_scale=args.repair_price_scale,
         )
         manifest.update(
-            status="completed",
+            status=final_status,
             completed_result_json_count=count_valid_results(
                 args.output_dir or plan["output_dir"],
                 include_error_files=False,


### PR DESCRIPTION
Closes #9

## Summary
- Restores the missing `os` import in `main.py` so product runs can create budget output directories.
- Preserves `completed_with_failures` manifest status after postprocessing when `--continue-on-error` records failed pair subprocesses.

## Verification
- `python3 main.py --products-file dataset/products_consumer_electronics.json --buyer-model openai/gpt-5.5 --seller-model openai/gpt-5.5 --summary-model openai/gpt-5.4-mini --num-experiments 1 --max-turns 10 --budget-scenarios mid --product-limit 1 --output-dir results/dry_run_check --dry-run`
- `python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 2 --product-limit 1 --budgets mid --parallel-workers 2`
- `python3 -m compileall main.py scripts/run_sweep.py`
- `python3 -m unittest discover -s tests`
- `python3 -m compileall Conversation.py main.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests`
- Live parallel pilot: `python3 scripts/run_sweep.py --mode all --max-pairs 2 --product-limit 1 --budgets mid --parallel-workers 2 --continue-on-error --run-id parallel_pilot_20260607_2000 --output-dir results/parallel_pilot_20260607_2000`

## Pilot outcome
- Manifest: `logs/run_sessions/parallel_pilot_20260607_2000/manifest.json`
- Expected cells: 2
- Completed valid result JSON: 2
- Failed pairs: 0
- Result files: 2
