### PR TITLE
Fail fast on provider key limits

### DIFF
--- a/Conversation.py
+++ b/Conversation.py
@@ -1,5 +1,5 @@
 import json
-from LanguageModel import LanguageModel, ModelCallError
+from LanguageModel import LanguageModel, ModelCallError, is_run_fatal_model_error
 import os
 import re
 from experiment_utils import (
@@ -102,6 +102,7 @@ class Conversation:
         self.negotiation_result = None
         self.data_error = False
         self.error = None
+        self.run_fatal_error = False
 
     def _model_error_event(self, exc, stage, role):
         if isinstance(exc, ModelCallError):
@@ -120,6 +121,7 @@ class Conversation:
         event = self._model_error_event(exc, stage=stage, role=role)
         self.data_error = True
         self.error = event
+        self.run_fatal_error = is_run_fatal_model_error(event.get("category"))
         self.negotiation_completed = True
         self.negotiation_result = "model_error"
         return event
@@ -128,6 +130,8 @@ class Conversation:
         error_event = self._model_error_event(exc, stage=stage, role="summary")
         event["summary_error"] = error_event
         self.data_error = True
+        if is_run_fatal_model_error(error_event.get("category")):
+            self.run_fatal_error = True
         if self.error is None:
             self.error = error_event
         return error_event
@@ -403,6 +407,8 @@ class Conversation:
             error_event = self._model_error_event(exc, stage="judge_confirmation", role="summary")
             event["confirmation_error"] = error_event
             self.data_error = True
+            if is_run_fatal_model_error(error_event.get("category")):
+                self.run_fatal_error = True
             if self.error is None:
                 self.error = error_event
             return current_label
@@ -461,6 +467,8 @@ class Conversation:
             raw_evaluation = ""
             summary_error = self._model_error_event(exc, stage="judge", role="summary")
             self.data_error = True
+            if is_run_fatal_model_error(summary_error.get("category")):
+                self.run_fatal_error = True
             if self.error is None:
                 self.error = summary_error
         else:
@@ -476,6 +484,11 @@ class Conversation:
             evaluation,
             normalize_warning=normalize_warning,
         )
+
+        if self.run_fatal_error:
+            self.negotiation_completed = True
+            self.negotiation_result = "model_error"
+            return True
         
         # Process the evaluation result
         if guarded_label == "ACCEPTANCE":
@@ -568,6 +581,12 @@ class Conversation:
             
             # Extract price offer using summary_model
             price_offer = self.extract_price_from_seller_message(seller_response)
+            if self.run_fatal_error:
+                self.completed_turns = turn_count - 1
+                self.negotiation_completed = True
+                self.negotiation_result = "model_error"
+                print(f"\n[Turn {turn_count}] Summary model hit a run-fatal error.")
+                break
             
             # If there's a price in this turn, update current price
             if price_offer is not None:
@@ -664,6 +683,7 @@ class Conversation:
                 "max_turns": self.max_turns
             },
             "data_error": self.data_error,
+            "run_fatal_error": self.run_fatal_error,
             "error": self.error,
         }
         

--- a/LanguageModel.py
+++ b/LanguageModel.py
@@ -21,6 +21,8 @@ _LITELLM_COMPLETION = None
 
 RETRIABLE_ERROR_CATEGORIES = {"rate_limit", "timeout", "transient", "empty_response"}
 FATAL_ERROR_CATEGORIES = {"auth", "billing_or_quota", "model_unavailable", "bad_request"}
+RUN_FATAL_ERROR_CATEGORIES = {"auth", "billing_or_quota", "model_unavailable", "bad_request"}
+RUN_FATAL_EXIT_CODE = 86
 
 
 MODEL_ALIASES = {
@@ -127,6 +129,19 @@ def classify_model_error(exc: Exception) -> str:
     status_code = _status_code_from_exception(exc)
     text = f"{type(exc).__name__}: {exc}".lower()
 
+    if any(
+        marker in text
+        for marker in (
+            "key limit exceeded",
+            "total limit",
+            "credit limit",
+            "spend limit",
+            "usage limit",
+            "quota exceeded",
+        )
+    ):
+        return "billing_or_quota"
+
     if status_code in {401, 403} or any(
         marker in text
         for marker in (
@@ -193,6 +208,10 @@ def classify_model_error(exc: Exception) -> str:
 
 def is_retriable_model_error(category: str) -> bool:
     return category in RETRIABLE_ERROR_CATEGORIES
+
+
+def is_run_fatal_model_error(category: str) -> bool:
+    return category in RUN_FATAL_ERROR_CATEGORIES
 
 
 class LanguageModel:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ failed pairs, and output directory. Resume logic counts only parseable result
 JSON files without `data_error` unless `--include-error-files` is explicitly
 provided.
 
+Provider key-limit, quota/billing, auth, invalid-model, and bad-request errors
+are treated as run-fatal. The current conversation is saved as evidence, the
+pair subprocess exits with a distinct fatal code, and the sweep manifest is
+marked `failed` instead of continuing to write unusable result files.
+
 The primary summary model is used for seller-offer extraction and negotiation
 state judging. To compare candidate summary models on fixed price/judge fixtures:
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import argparse
 import os
+import sys
 from Conversation import Conversation
+from LanguageModel import RUN_FATAL_EXIT_CODE
 from experiment_utils import (
     SUPPORTED_BUDGET_SCENARIOS,
     calculate_budget_scenarios,
@@ -116,6 +118,13 @@ def _run_product_experiment(
             
             # Save conversation
             conversation.save_conversation(full_output_dir)
+
+            if conversation.run_fatal_error:
+                print(
+                    "Run-fatal model error encountered. "
+                    f"Stopping subprocess with exit code {RUN_FATAL_EXIT_CODE}."
+                )
+                sys.exit(RUN_FATAL_EXIT_CODE)
             
             # Print summary of the completed negotiation
             print(f"\nExperiment {existing_count + exp_num + 1} completed and saved to {full_output_dir}")

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -13,6 +13,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from experiment_utils import count_valid_results, load_products, parse_csv, safe_path_name
+from LanguageModel import RUN_FATAL_EXIT_CODE
+
+
+class FatalSweepError(RuntimeError):
+    def __init__(self, result):
+        self.result = result
+        super().__init__(f"Fatal sweep error in {result.get('pair_id')}: returncode {result.get('returncode')}")
 
 
 def utc_now():
@@ -197,12 +204,16 @@ def run_pair(plan, seller, buyer, kind, args, manifest=None, session_dir=None):
         "buyer": buyer["model"],
         "kind": kind,
         "returncode": completed.returncode,
+        "run_fatal": completed.returncode == RUN_FATAL_EXIT_CODE,
         "started_at": started_at,
         "finished_at": utc_now(),
         "log_path": str(log_path) if log_path else None,
     }
     if manifest is not None:
         manifest.pair_finished(identifier, result)
+
+    if completed.returncode == RUN_FATAL_EXIT_CODE:
+        raise FatalSweepError(result)
 
     if completed.returncode != 0 and not args.continue_on_error:
         raise subprocess.CalledProcessError(completed.returncode, cmd)
@@ -252,6 +263,14 @@ def run_pairs(plan, pairs, args, manifest=None, session_dir=None):
         for future in concurrent.futures.as_completed(future_to_pair):
             try:
                 results.append(future.result())
+            except FatalSweepError as exc:
+                results.append(exc.result)
+                for pending in future_to_pair:
+                    if pending is not future:
+                        pending.cancel()
+                if manifest is not None:
+                    manifest.event("fatal_pair_error", **exc.result)
+                raise
             except Exception as exc:
                 seller, buyer, kind = future_to_pair[future]
                 failure = {
@@ -340,6 +359,9 @@ def main():
         failed_pairs = manifest.payload.get("failed_pairs", [])
         final_status = "completed_with_failures" if failed_pairs else "completed"
         manifest.update(status=final_status)
+    except FatalSweepError as exc:
+        manifest.update(status="failed", fatal_error=exc.result)
+        raise SystemExit(RUN_FATAL_EXIT_CODE) from exc
     except Exception:
         manifest.update(status="failed")
         raise

--- a/tests/test_conversation_judge.py
+++ b/tests/test_conversation_judge.py
@@ -34,6 +34,21 @@ class FailingModel:
         raise ModelCallError("fake-model", self.category, "fake failure", attempts=1)
 
 
+class StaticModel:
+    def __init__(self, response):
+        self.response = response
+        self.response_calls = 0
+        self.chat_calls = 0
+
+    def get_response(self, _prompt):
+        self.response_calls += 1
+        return self.response
+
+    def get_chat_response(self, _messages):
+        self.chat_calls += 1
+        return self.response
+
+
 def make_conversation(summary_response="CONTINUE", budget=211.5, seller_offer=225):
     conversation = Conversation(
         PRODUCT,
@@ -149,6 +164,21 @@ class ConversationJudgeTest(unittest.TestCase):
             conversation.save_conversation(tmp_dir)
             output = (Path(tmp_dir) / "product_1_exp_0.json").read_text(encoding="utf-8")
             self.assertIn('"data_error": true', output)
+
+    def test_summary_run_fatal_stops_before_next_buyer_turn(self):
+        conversation = make_conversation(summary_response="CONTINUE")
+        buyer_model = StaticModel("Hello, can we discuss the price?")
+        conversation.buyer_model = buyer_model
+        conversation.seller_model = StaticModel("I can do $225.")
+        conversation.summary_model = FailingModel("billing_or_quota")
+
+        conversation.run_negotiation()
+
+        self.assertTrue(conversation.data_error)
+        self.assertTrue(conversation.run_fatal_error)
+        self.assertEqual(conversation.negotiation_result, "model_error")
+        self.assertEqual(buyer_model.response_calls, 1)
+        self.assertEqual(buyer_model.chat_calls, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_fatal_provider_handling.py
+++ b/tests/test_fatal_provider_handling.py
@@ -1,0 +1,90 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import main
+import scripts.run_sweep as run_sweep
+from LanguageModel import RUN_FATAL_EXIT_CODE
+
+
+PRODUCT = {
+    "id": 1,
+    "Product Name": "AirPods Pro 2",
+    "Retail Price": "$249",
+    "Wholesale Price": "$174",
+    "Features": "Noise cancellation and spatial audio",
+}
+
+
+class FakeFatalConversation:
+    def __init__(self, *args, **kwargs):
+        self.run_fatal_error = True
+        self.completed_turns = 0
+        self.negotiation_completed = True
+        self.negotiation_result = "model_error"
+        self.current_price_offer = None
+        self.budget_scenario = None
+
+    def run_negotiation(self):
+        return []
+
+    def save_conversation(self, output_dir):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+
+class FatalProviderHandlingTest(unittest.TestCase):
+    def test_main_exits_after_saving_run_fatal_conversation(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.object(main, "Conversation", FakeFatalConversation):
+                with self.assertRaises(SystemExit) as ctx:
+                    main._run_product_experiment(
+                        product_index=0,
+                        product=PRODUCT,
+                        buyer_model="buyer",
+                        seller_model="seller",
+                        summary_model="summary",
+                        max_turns=1,
+                        num_experiments=1,
+                        output_dir=tmp_dir,
+                        budget_scenarios=["mid"],
+                    )
+
+        self.assertEqual(ctx.exception.code, RUN_FATAL_EXIT_CODE)
+
+    def test_run_pair_raises_fatal_sweep_error_for_fatal_exit_code(self):
+        args = SimpleNamespace(
+            products_file=None,
+            summary_model=None,
+            max_turns=None,
+            num_experiments=None,
+            budgets=None,
+            output_dir=None,
+            product_limit=None,
+            include_error_files=False,
+            dry_run=False,
+            continue_on_error=True,
+            judge_confirmation_model=None,
+        )
+        plan = {
+            "products_file": "dataset/products_mini.json",
+            "summary_model": "summary",
+            "max_turns": 1,
+            "num_experiments": 1,
+            "budgets": ["mid"],
+            "output_dir": "results/test",
+        }
+        seller = {"label": "Seller", "model": "seller-model"}
+        buyer = {"label": "Buyer", "model": "buyer-model"}
+
+        with patch.object(run_sweep.subprocess, "run", return_value=SimpleNamespace(returncode=RUN_FATAL_EXIT_CODE)):
+            with self.assertRaises(run_sweep.FatalSweepError) as ctx:
+                run_sweep.run_pair(plan, seller, buyer, "test-kind", args)
+
+        self.assertTrue(ctx.exception.result["run_fatal"])
+        self.assertEqual(ctx.exception.result["returncode"], RUN_FATAL_EXIT_CODE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -34,6 +34,10 @@ class LanguageModelTest(unittest.TestCase):
     def test_classify_billing_and_auth_errors(self):
         self.assertEqual(classify_model_error(FakeProviderError("Payment required", 402)), "billing_or_quota")
         self.assertEqual(classify_model_error(FakeProviderError("invalid api key", 401)), "auth")
+        self.assertEqual(
+            classify_model_error(FakeProviderError("Key limit exceeded (total limit)", 403)),
+            "billing_or_quota",
+        )
 
     def test_fatal_provider_error_does_not_retry(self):
         calls = []


### PR DESCRIPTION
Closes #11

## Summary
- Classifies OpenRouter key total-limit / spend-limit / quota-limit messages as `billing_or_quota` instead of generic auth.
- Adds run-fatal error state to conversations and saves a single evidence JSON with `run_fatal_error=true`.
- Makes `main.py` exit with a distinct fatal code after saving that evidence.
- Makes `scripts/run_sweep.py` stop the whole sweep on that fatal code even when `--continue-on-error` is set, and marks the manifest `failed` with `fatal_error` details.
- Documents the run-fatal behavior in README.

## Verification
- `python3 -m unittest discover -s tests`
- `python3 -m compileall Conversation.py main.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests`
- `python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 1 --product-limit 1 --parallel-workers 2`

## Notes
This prevents another OpenRouter key-limit event from producing thousands of unusable `data_error` files.
