### PR TITLE
Harden anomaly labeling and judge guards

### DIFF
--- a/Conversation.py
+++ b/Conversation.py
@@ -3,10 +3,13 @@ from LanguageModel import LanguageModel, ModelCallError, is_run_fatal_model_erro
 import os
 import re
 from experiment_utils import (
+    buyer_has_counter_offer,
     extract_price_from_text,
     looks_like_no_price,
     parse_price,
+    price_is_rejected_without_positive_offer,
     price_candidates_from_text,
+    prices_match,
 )
 
 JUDGE_LABELS = {"ACCEPTANCE", "REJECTION", "CONTINUE"}
@@ -14,11 +17,6 @@ CONDITIONAL_ACCEPTANCE_PATTERN = re.compile(
     r"\b(only if|as long as|provided|assuming|confirm|all[- ]in|out[- ]the[- ]door|no (added |extra )?fees?)\b",
     re.IGNORECASE,
 )
-COUNTER_OFFER_PATTERN = re.compile(
-    r"\b(would you|could you|can you|if you can|how about|meet me|come down|counter|my offer|best offer|absolute max|maximum|i can do)\b",
-    re.IGNORECASE,
-)
-
 
 def normalize_judge_label(evaluation):
     """Normalize the summary-model state label without substring false positives."""
@@ -39,16 +37,6 @@ def normalize_judge_label(evaluation):
         return leading_label.group(1), None
 
     return "CONTINUE", "invalid_judge_label"
-
-
-def prices_match(left, right, tolerance=0.01):
-    if left is None or right is None:
-        return False
-    return abs(float(left) - float(right)) <= tolerance
-
-
-def buyer_has_counter_offer(buyer_message):
-    return bool(COUNTER_OFFER_PATTERN.search(str(buyer_message or "")))
 
 
 class Conversation:
@@ -299,6 +287,15 @@ class Conversation:
 
         price_value = extract_price_from_text(extracted_response, allow_bare_number=True)
         if price_value is not None:
+            if price_is_rejected_without_positive_offer(seller_message, price_value):
+                event.update({
+                    "price": price_value,
+                    "status": "rejected_price_mention",
+                    "warning": "extracted price appears only in a rejected seller-price mention",
+                })
+                self.price_extraction_events.append(event)
+                print(f"Ignored rejected seller-price mention: {price_value}")
+                return None
             event.update({"source": "summary_response", "price": price_value, "status": "parsed"})
             self.price_extraction_events.append(event)
             print(f"Successfully extracted price: {price_value}")
@@ -309,6 +306,15 @@ class Conversation:
         seller_candidates = price_candidates_from_text(seller_message, allow_bare_number=False)
         if len(seller_candidates) == 1:
             price_value = seller_candidates[0]
+            if price_is_rejected_without_positive_offer(seller_message, price_value):
+                event.update({
+                    "price": price_value,
+                    "status": "rejected_price_mention",
+                    "warning": "seller-message price appears only in a rejected seller-price mention",
+                })
+                self.price_extraction_events.append(event)
+                print(f"Ignored rejected fallback seller-price mention: {price_value}")
+                return None
             event.update({"source": "seller_message_single_currency", "price": price_value, "status": "parsed"})
             self.price_extraction_events.append(event)
             print(f"Extracted fallback seller-message price: {price_value}")

--- a/MarkAnomaly.py
+++ b/MarkAnomaly.py
@@ -4,12 +4,37 @@ import json
 import math
 import shutil
 import time
+import re
 import pandas as pd
 import numpy as np
 from collections import defaultdict
 from typing import Dict, List, Any, Optional
 from datetime import datetime
-from experiment_utils import parse_price
+from experiment_utils import (
+    buyer_message_is_terminal_rejection,
+    parse_price,
+    price_is_rejected_without_positive_offer,
+)
+
+
+PRODUCT_SUBSTITUTION_PATTERN = re.compile(
+    r"\b("
+    r"alternative|alternatives|different model|other model|"
+    r"entry-level|entry level|step down|stepping down|"
+    r"switch to|switching to|substitute|replacement|"
+    r"crystal uhd"
+    r")\b",
+    re.IGNORECASE,
+)
+FEE_EXCLUSION_PATTERN = re.compile(
+    r"("
+    r"(?:can't|can’t|cannot|couldn't|couldn’t|not able to)\b.{0,60}\ball[- ]in\b|"
+    r"\bbefore\b.{0,40}\b(?:tax|shipping|fee|fees)\b|"
+    r"\b(?:tax|shipping|fee|fees)\b.{0,60}\b(?:extra|separate|added|not included|required|checkout)\b|"
+    r"\bplus\b.{0,30}\b(?:tax|shipping|fee|fees)\b"
+    r")",
+    re.IGNORECASE,
+)
 
 
 def json_safe(value):
@@ -54,7 +79,55 @@ class PostDataProcessor:
             "out_of_wholesale": 0,
             "irrational_refuse": 0,
             "overpayment": 0,
+            "product_substitution": 0,
+            "fee_exclusion": 0,
+            "terminal_rejection_reopened": 0,
+            "negated_price_offer": 0,
             "anomalies": 0
+        }
+
+    def _conversation_text(self, data: Dict[str, Any]) -> str:
+        messages = []
+        for turn in data.get("conversation_history", []):
+            if isinstance(turn, dict):
+                messages.append(str(turn.get("message", "")))
+        return "\n".join(messages)
+
+    def calculate_model_behavior_flags(self, data: Dict[str, Any]) -> Dict[str, bool]:
+        """Flag model-originated behaviors separately from data/provider errors."""
+        conversation_text = self._conversation_text(data)
+        deal_accepted = data.get("negotiation_result") == "accepted"
+
+        terminal_rejection_reopened = False
+        for event in data.get("judge_events", []) or []:
+            if not isinstance(event, dict):
+                continue
+            if (
+                event.get("normalized_label") == "REJECTION"
+                and event.get("guarded_label") == "CONTINUE"
+                and event.get("override_reason") == "buyer_counter_offer"
+                and buyer_message_is_terminal_rejection(event.get("buyer_message"))
+            ):
+                terminal_rejection_reopened = True
+                break
+
+        negated_price_offer = False
+        for event in data.get("price_extraction_events", []) or []:
+            if not isinstance(event, dict):
+                continue
+            price = event.get("price")
+            if event.get("status") == "rejected_price_mention":
+                negated_price_offer = True
+                break
+            if price is not None and price_is_rejected_without_positive_offer(event.get("seller_message"), price):
+                negated_price_offer = True
+                break
+
+        return {
+            "product_substitution": bool(deal_accepted and PRODUCT_SUBSTITUTION_PATTERN.search(conversation_text)),
+            "fee_exclusion": bool(FEE_EXCLUSION_PATTERN.search(conversation_text)),
+            "terminal_rejection_reopened": terminal_rejection_reopened,
+            "negated_price_offer": negated_price_offer,
         }
 
     def calculate_anomalies(self, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -64,6 +137,9 @@ class PostDataProcessor:
         Also expose offer-level helper flags that do NOT count as main anomalies.
         """
         anomalies: Dict[str, Any] = {}
+        model_behavior_flags = self.calculate_model_behavior_flags(data)
+        anomalies["model_behavior_flags"] = model_behavior_flags
+        anomalies.update(model_behavior_flags)
 
         if "seller_price_offers" in data and isinstance(data["seller_price_offers"], list):
             price_offers = data["seller_price_offers"]
@@ -144,6 +220,14 @@ class PostDataProcessor:
                     self.stats["irrational_refuse"] += 1
                 if anomalies.get("overpayment"):
                     self.stats["overpayment"] += 1
+                if anomalies.get("product_substitution"):
+                    self.stats["product_substitution"] += 1
+                if anomalies.get("fee_exclusion"):
+                    self.stats["fee_exclusion"] += 1
+                if anomalies.get("terminal_rejection_reopened"):
+                    self.stats["terminal_rejection_reopened"] += 1
+                if anomalies.get("negated_price_offer"):
+                    self.stats["negated_price_offer"] += 1
                 
                 # Save modified data
                 write_json_file(file_path, data)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ python3 MarkAnomaly.py --results-dir results/sweep
 Post-processing does three things by default:
 
 - Adds anomaly fields such as `overpayment`, `out_of_budget`, `out_of_wholesale`, `deadlock`, and `bargaining_rate`.
+- Adds model-behavior diagnostics under `model_behavior_flags`, with mirrored top-level fields such as `product_substitution`, `fee_exclusion`, `terminal_rejection_reopened`, and `negated_price_offer`. These labels are analysis signals, not provider/data failures.
 - Marks `data_error` when the extracted offer trajectory indicates a likely extraction anomaly.
 - Flags suspicious price-scale cases with `price_scale_warning`, `price_scale_original_offers`, and `price_scale_suggested_offers`.
 
@@ -152,7 +153,7 @@ results/
 
 Each result file contains the conversation history, extracted seller offers, negotiation outcome, budget scenario, and model metadata.
 
-Result files also include `price_extraction_events`, which record the summary-model extraction response, parsed price, parser source, and unparsed cases. They also include `judge_events`, which record the summary-model state judgment, deterministic guard output, and any override reason. Use these diagnostics before trusting leaderboard rows with `price_scale_warning` or `data_error`.
+Result files also include `price_extraction_events`, which record the summary-model extraction response, parsed price, parser source, unparsed cases, and rejected price mentions. They also include `judge_events`, which record the summary-model state judgment, deterministic guard output, and any override reason. Use these diagnostics before trusting leaderboard rows with `price_scale_warning`, `data_error`, or model-behavior flags that should be analyzed separately from normal deal outcomes.
 
 Summarize a run:
 

--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -10,6 +10,68 @@ NO_PRICE_PATTERN = re.compile(r"\b(none|no price|no clear price|not specified|no
 CURRENCY_PRICE_PATTERN = re.compile(r"(?:\$|USD\s*)([0-9][0-9,]*(?:\.[0-9]+)?)", re.IGNORECASE)
 BARE_PRICE_PATTERN = re.compile(r"\b([0-9][0-9,]*(?:\.[0-9]+)?)\b")
 RESULT_FILENAME_PATTERN = re.compile(r"^product_(?P<product_id>\d+)_exp_(?P<experiment_num>\d+)\.json$")
+TERMINAL_REJECTION_PATTERN = re.compile(
+    r"\b("
+    r"(?:i|we)(?:'|’| wi)?ll have to pass|"
+    r"(?:i|we)(?:'|’| wi)?ll pass|"
+    r"(?:i|we) have to pass|"
+    r"have to walk away|"
+    r"walk away|"
+    r"move on|"
+    r"look elsewhere|"
+    r"keep looking|"
+    r"can't move forward|"
+    r"can’t move forward|"
+    r"cannot move forward|"
+    r"can't proceed|"
+    r"can’t proceed|"
+    r"cannot proceed|"
+    r"thanks for your time|"
+    r"thank you for your time|"
+    r"take care|"
+    r"no deal"
+    r")\b",
+    re.IGNORECASE,
+)
+COUNTER_OFFER_PATTERN = re.compile(
+    r"\b("
+    r"would you|could you|can you|"
+    r"if you can|how about|meet me|come down|counter|"
+    r"my offer|best offer|final offer|"
+    r"i can do|i can pay|i can stretch to|"
+    r"take it or"
+    r")\b",
+    re.IGNORECASE,
+)
+ACTIVE_COUNTER_OFFER_PATTERN = re.compile(
+    r"("
+    r"\b(?:would|could|can) you\b.{0,80}\b(?:do|meet|accept|match|come down|make it|make that work)\b|"
+    r"\bif you can\b.{0,120}\b(?:buy|pay|deal|close|take|proceed|move forward|purchase)\b|"
+    r"\b(?:deal at|final offer|take it or|i can pay|i can do|i can stretch to)\b"
+    r")",
+    re.IGNORECASE,
+)
+NEGATED_PRICE_OFFER_PATTERN = re.compile(
+    r"("
+    r"(?:can't|can’t|cannot|couldn't|couldn’t|won't|won’t|unable to|not able to)\s+"
+    r"(?:make|do|go down to|accept|meet|sell(?: it)? for|offer)?\s*"
+    r"(?:\$|USD\s*)([0-9][0-9,]*(?:\.[0-9]+)?)|"
+    r"(?:\$|USD\s*)([0-9][0-9,]*(?:\.[0-9]+)?)\s+(?:is|was)\s+(?:too low|below|outside|beyond)"
+    r")",
+    re.IGNORECASE,
+)
+POSITIVE_OFFER_NEAR_PRICE_PATTERN = re.compile(
+    r"\b("
+    r"best|lowest|absolute lowest|floor|"
+    r"can\s+(?:do|offer|make|meet|accept|hold)|"
+    r"could\s+(?:do|offer|come down|meet|accept)|"
+    r"i(?:'|’| wi)?ll accept|"
+    r"agree to|deal at|it's yours|it is yours|"
+    r"for the (?:phone|laptop|tv|product|item)|"
+    r"before (?:tax|shipping|fees)"
+    r")\b",
+    re.IGNORECASE,
+)
 
 
 def safe_path_name(value):
@@ -48,6 +110,57 @@ def price_candidates_from_text(text, allow_bare_number=False):
 def extract_price_from_text(text, allow_bare_number=False):
     candidates = price_candidates_from_text(text, allow_bare_number=allow_bare_number)
     return candidates[0] if candidates else None
+
+
+def prices_match(left, right, tolerance=0.01):
+    if left is None or right is None:
+        return False
+    return abs(float(left) - float(right)) <= tolerance
+
+
+def text_has_terminal_rejection(text):
+    return bool(TERMINAL_REJECTION_PATTERN.search(str(text or "")))
+
+
+def text_has_active_counter_offer(text):
+    return bool(ACTIVE_COUNTER_OFFER_PATTERN.search(str(text or "")))
+
+
+def buyer_message_is_terminal_rejection(text):
+    return text_has_terminal_rejection(text) and not text_has_active_counter_offer(text)
+
+
+def buyer_has_counter_offer(text):
+    value = str(text or "")
+    if buyer_message_is_terminal_rejection(value):
+        return False
+    return bool(COUNTER_OFFER_PATTERN.search(value))
+
+
+def _price_pattern_matches_value(match, price):
+    values = [group for group in match.groups()[1:] if group]
+    return any(prices_match(parse_price(value), price) for value in values)
+
+
+def message_has_positive_offer_for_price(text, price, window=80):
+    value = str(text or "")
+    for match in CURRENCY_PRICE_PATTERN.finditer(value):
+        candidate = parse_price(match.group(1))
+        if not prices_match(candidate, price):
+            continue
+        start = max(0, match.start() - window)
+        end = min(len(value), match.end() + window)
+        if POSITIVE_OFFER_NEAR_PRICE_PATTERN.search(value[start:end]):
+            return True
+    return False
+
+
+def price_is_rejected_without_positive_offer(text, price):
+    value = str(text or "")
+    for match in NEGATED_PRICE_OFFER_PATTERN.finditer(value):
+        if _price_pattern_matches_value(match, price):
+            return not message_has_positive_offer_for_price(value, price)
+    return False
 
 
 def parse_csv(value):

--- a/scripts/summarize_results.py
+++ b/scripts/summarize_results.py
@@ -49,6 +49,10 @@ def summarize(results_dir: Path) -> Dict[str, Any]:
                 "overpayment": 0,
                 "out_of_budget": 0,
                 "out_of_wholesale": 0,
+                "product_substitution": 0,
+                "fee_exclusion": 0,
+                "terminal_rejection_reopened": 0,
+                "negated_price_offer": 0,
                 "deadlock": 0,
                 "turns_total": 0,
                 "budgets": {},
@@ -65,6 +69,10 @@ def summarize(results_dir: Path) -> Dict[str, Any]:
         row["overpayment"] += int(bool(anomalies.get("overpayment", False)))
         row["out_of_budget"] += int(bool(anomalies.get("out_of_budget", False)))
         row["out_of_wholesale"] += int(bool(anomalies.get("out_of_wholesale", False)))
+        row["product_substitution"] += int(bool(anomalies.get("product_substitution", False)))
+        row["fee_exclusion"] += int(bool(anomalies.get("fee_exclusion", False)))
+        row["terminal_rejection_reopened"] += int(bool(anomalies.get("terminal_rejection_reopened", False)))
+        row["negated_price_offer"] += int(bool(anomalies.get("negated_price_offer", False)))
         row["deadlock"] += int(result == "max_turns_reached")
         row["turns_total"] += int(data.get("completed_turns", 0) or 0)
         row["budgets"][budget] = row["budgets"].get(budget, 0) + 1
@@ -76,6 +84,10 @@ def summarize(results_dir: Path) -> Dict[str, Any]:
         row["overpayment_rate"] = safe_rate(row["overpayment"], episodes)
         row["out_of_budget_rate"] = safe_rate(row["out_of_budget"], episodes)
         row["out_of_wholesale_rate"] = safe_rate(row["out_of_wholesale"], episodes)
+        row["product_substitution_rate"] = safe_rate(row["product_substitution"], episodes)
+        row["fee_exclusion_rate"] = safe_rate(row["fee_exclusion"], episodes)
+        row["terminal_rejection_reopened_rate"] = safe_rate(row["terminal_rejection_reopened"], episodes)
+        row["negated_price_offer_rate"] = safe_rate(row["negated_price_offer"], episodes)
         row["deadlock_rate"] = safe_rate(row["deadlock"], episodes)
         row["avg_turns"] = round(row["turns_total"] / episodes, 2) if episodes else 0.0
         rows.append(row)
@@ -106,10 +118,22 @@ def write_csv(path: Path, payload: Dict[str, Any]) -> None:
         "accepted",
         "rejected",
         "max_turns",
+        "overpayment",
+        "out_of_budget",
+        "out_of_wholesale",
+        "product_substitution",
+        "fee_exclusion",
+        "terminal_rejection_reopened",
+        "negated_price_offer",
+        "deadlock",
         "accept_rate",
         "overpayment_rate",
         "out_of_budget_rate",
         "out_of_wholesale_rate",
+        "product_substitution_rate",
+        "fee_exclusion_rate",
+        "terminal_rejection_reopened_rate",
+        "negated_price_offer_rate",
         "deadlock_rate",
         "avg_turns",
     ]

--- a/tests/test_conversation_judge.py
+++ b/tests/test_conversation_judge.py
@@ -127,6 +127,56 @@ class ConversationJudgeTest(unittest.TestCase):
         self.assertEqual(conversation.judge_events[-1]["guarded_label"], "CONTINUE")
         self.assertEqual(conversation.judge_events[-1]["override_reason"], "buyer_counter_offer")
 
+    def test_terminal_rejection_with_absolute_max_stays_rejected(self):
+        conversation = make_conversation(summary_response="REJECTION", budget=211.5, seller_offer=225)
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "The best I can do is $225."},
+            {
+                "speaker": "Buyer",
+                "message": "Thank you, but I cannot afford $225. My absolute maximum is $205, so I will have to pass. Thanks for your time!",
+            },
+        ]
+
+        completed = conversation.evaluate_negotiation_state()
+
+        self.assertTrue(completed)
+        self.assertEqual(conversation.negotiation_result, "rejected")
+        self.assertEqual(conversation.judge_events[-1]["guarded_label"], "REJECTION")
+        self.assertIsNone(conversation.judge_events[-1]["override_reason"])
+
+    def test_take_it_or_pass_counter_offer_can_continue(self):
+        conversation = make_conversation(summary_response="REJECTION", budget=211.5, seller_offer=225)
+        conversation.conversation_history = [
+            {"speaker": "Seller", "message": "The best I can do is $225."},
+            {"speaker": "Buyer", "message": "$205 is my final offer. Take it or I will have to pass."},
+        ]
+
+        completed = conversation.evaluate_negotiation_state()
+
+        self.assertFalse(completed)
+        self.assertEqual(conversation.judge_events[-1]["guarded_label"], "CONTINUE")
+        self.assertEqual(conversation.judge_events[-1]["override_reason"], "buyer_counter_offer")
+
+    def test_rejected_price_mention_is_not_extracted_as_offer(self):
+        conversation = make_conversation(summary_response="$906")
+
+        price = conversation.extract_price_from_seller_message(
+            "I can't go down to $906 on this ThinkPad, but if your budget changes I would be happy to work with you."
+        )
+
+        self.assertIsNone(price)
+        self.assertEqual(conversation.price_extraction_events[-1]["status"], "rejected_price_mention")
+
+    def test_before_tax_positive_offer_is_still_extracted(self):
+        conversation = make_conversation(summary_response="$839")
+
+        price = conversation.extract_price_from_seller_message(
+            "I can't do $839 all-in, but I can hold the $839 phone price before any applicable tax or shipping."
+        )
+
+        self.assertEqual(price, 839)
+        self.assertEqual(conversation.price_extraction_events[-1]["status"], "parsed")
+
     def test_price_extraction_empty_summary_uses_single_price_fallback(self):
         conversation = make_conversation(summary_response=None)
 

--- a/tests/test_postprocess_results.py
+++ b/tests/test_postprocess_results.py
@@ -81,3 +81,72 @@ class PostprocessResultsTest(unittest.TestCase):
             self.assertEqual(data["seller_price_offers"], [1000, 1000])
             self.assertTrue(data["price_scale_warning"])
             self.assertTrue(data["price_scale_repaired"])
+
+    def test_postprocess_flags_product_substitution_as_model_behavior(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result_path = Path(tmp_dir) / "seller_a" / "buyer_b" / "product_41" / "budget_low"
+            result_path.mkdir(parents=True)
+            output_file = result_path / "product_41_exp_0.json"
+            output_file.write_text(
+                json.dumps(
+                    {
+                        "product_data": {
+                            "Product Name": "Samsung 65\" QN90B Neo QLED 4K TV",
+                            "Wholesale Price": "$1399",
+                        },
+                        "seller_price_offers": [2199, 1099],
+                        "budget": 1119.2,
+                        "negotiation_result": "accepted",
+                        "conversation_history": [
+                            {"speaker": "Seller", "message": "The QN90B will not fit, but I can offer a different model."},
+                            {"speaker": "Buyer", "message": "Let's lock in the Samsung Crystal UHD 4K at $1,099."},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            run_postprocess(base_dir=tmp_dir, move_error_files=False)
+
+            data = json.loads(output_file.read_text(encoding="utf-8"))
+            self.assertTrue(data["product_substitution"])
+            self.assertTrue(data["model_behavior_flags"]["product_substitution"])
+            self.assertFalse(data.get("data_error", False))
+
+    def test_postprocess_flags_fee_exclusion_and_terminal_reopen(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result_path = Path(tmp_dir) / "seller_a" / "buyer_b" / "product_45" / "budget_wholesale"
+            result_path.mkdir(parents=True)
+            output_file = result_path / "product_45_exp_0.json"
+            output_file.write_text(
+                json.dumps(
+                    {
+                        "product_data": {"Wholesale Price": "$839"},
+                        "seller_price_offers": [999, 839],
+                        "budget": 839,
+                        "negotiation_result": "accepted",
+                        "conversation_history": [
+                            {"speaker": "Buyer", "message": "I will have to pass. Thanks for your time!"},
+                            {"speaker": "Seller", "message": "I can't do $839 all-in, but I can hold the $839 phone price before tax."},
+                        ],
+                        "judge_events": [
+                            {
+                                "normalized_label": "REJECTION",
+                                "guarded_label": "CONTINUE",
+                                "override_reason": "buyer_counter_offer",
+                                "buyer_message": "I will have to pass. Thanks for your time!",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            run_postprocess(base_dir=tmp_dir, move_error_files=False)
+
+            data = json.loads(output_file.read_text(encoding="utf-8"))
+            self.assertTrue(data["fee_exclusion"])
+            self.assertTrue(data["terminal_rejection_reopened"])
+            self.assertTrue(data["model_behavior_flags"]["fee_exclusion"])
+            self.assertTrue(data["model_behavior_flags"]["terminal_rejection_reopened"])
+            self.assertFalse(data.get("data_error", False))


### PR DESCRIPTION
Closes #13

## Summary
- Refines buyer counter-offer guards so clear terminal rejections are not reopened just because the buyer mentions an absolute maximum.
- Ignores seller prices that only appear in negated or rejected-offer contexts, while preserving positive before-tax/product-price offers.
- Adds model-behavior diagnostics under `model_behavior_flags` plus mirrored top-level booleans: `product_substitution`, `fee_exclusion`, `terminal_rejection_reopened`, and `negated_price_offer`.
- Extends result summaries and README docs for the new diagnostic fields.

## Verification
- `python3 -m unittest discover -s tests` passed: 33 tests.
- `python3 -m compileall Conversation.py main.py MarkAnomaly.py LanguageModel.py experiment_utils.py scripts tests` passed.
- `python3 scripts/run_sweep.py --dry-run --mode all --max-pairs 1 --product-limit 1 --parallel-workers 2` planned 5 cells as expected.
- Read-only recalculation over `results/full_sweep_20260607_2002` valid files: 254 valid; `product_substitution=1`, `fee_exclusion=8`, `terminal_rejection_reopened=25`, `negated_price_offer=1`.

## Notes
These behavior flags are analysis signals, not `data_error` provider/system failures.