### PR TITLE
Add provider usage accounting

### DIFF
--- a/Conversation.py
+++ b/Conversation.py
@@ -10,6 +10,7 @@ from experiment_utils import (
     price_is_rejected_without_positive_offer,
     price_candidates_from_text,
     prices_match,
+    summarize_usage_events,
 )
 
 JUDGE_LABELS = {"ACCEPTANCE", "REJECTION", "CONTINUE"}
@@ -79,6 +80,7 @@ class Conversation:
         self.seller_price_offers = []
         self.price_extraction_events = []
         self.judge_events = []
+        self.usage_events = []
         # Add the original retail price as the first element
         retail_price_str = product_data["Retail Price"]
         self.seller_price_offers.append(parse_price(retail_price_str))
@@ -123,6 +125,18 @@ class Conversation:
         if self.error is None:
             self.error = error_event
         return error_event
+
+    def _record_usage(self, stage, role, model):
+        consume = getattr(model, "consume_usage_events", None)
+        if not callable(consume):
+            return
+        for event in consume():
+            usage_event = dict(event)
+            usage_event.update({"stage": stage, "role": role})
+            self.usage_events.append(usage_event)
+
+    def usage_summary(self):
+        return summarize_usage_events(self.usage_events)
         
     def format_buyer_prompt(self):
         """Format a prompt for the buyer agent."""
@@ -257,8 +271,11 @@ class Conversation:
         try:
             raw_extracted_response = self.summary_model.get_response(prompt)
         except ModelCallError as exc:
+            self._record_usage("price_extraction", "summary", self.summary_model)
             summary_error = exc
             raw_extracted_response = None
+        else:
+            self._record_usage("price_extraction", "summary", self.summary_model)
         extracted_response = "" if raw_extracted_response is None else raw_extracted_response.strip()
         
         event = {
@@ -410,6 +427,7 @@ class Conversation:
         try:
             raw_confirmation = self.judge_confirmation_model.get_response(prompt)
         except ModelCallError as exc:
+            self._record_usage("judge_confirmation", "summary", self.judge_confirmation_model)
             error_event = self._model_error_event(exc, stage="judge_confirmation", role="summary")
             event["confirmation_error"] = error_event
             self.data_error = True
@@ -418,6 +436,8 @@ class Conversation:
             if self.error is None:
                 self.error = error_event
             return current_label
+        else:
+            self._record_usage("judge_confirmation", "summary", self.judge_confirmation_model)
 
         confirmation = "" if raw_confirmation is None else raw_confirmation.strip()
         confirmation_label, confirmation_warning = normalize_judge_label(confirmation)
@@ -470,6 +490,7 @@ class Conversation:
         try:
             raw_evaluation = self.summary_model.get_response(evaluation_prompt)
         except ModelCallError as exc:
+            self._record_usage("judge", "summary", self.summary_model)
             raw_evaluation = ""
             summary_error = self._model_error_event(exc, stage="judge", role="summary")
             self.data_error = True
@@ -478,6 +499,7 @@ class Conversation:
             if self.error is None:
                 self.error = summary_error
         else:
+            self._record_usage("judge", "summary", self.summary_model)
             summary_error = None
         evaluation = "" if raw_evaluation is None else raw_evaluation.strip()
         normalized_label, normalize_warning = normalize_judge_label(evaluation)
@@ -536,11 +558,14 @@ class Conversation:
         try:
             buyer_intro = self.buyer_model.get_response(intro_prompt)
         except ModelCallError as exc:
+            self._record_usage("buyer_intro", "buyer", self.buyer_model)
             self.current_price_offer = self.seller_price_offers[0]
             self.completed_turns = 0
             self._record_data_error(exc, stage="buyer_intro", role="buyer")
             print(f"\n[Initial] Buyer model failed: {exc.category}")
             return self.conversation_history
+        else:
+            self._record_usage("buyer_intro", "buyer", self.buyer_model)
 
         if buyer_intro is None or not str(buyer_intro).strip():
             self.current_price_offer = self.seller_price_offers[0]
@@ -567,10 +592,13 @@ class Conversation:
             try:
                 seller_response = self.seller_model.get_chat_response(seller_messages)
             except ModelCallError as exc:
+                self._record_usage(f"turn_{turn_count}_seller", "seller", self.seller_model)
                 self.completed_turns = turn_count - 1
                 self._record_data_error(exc, stage=f"turn_{turn_count}_seller", role="seller")
                 print(f"\n[Turn {turn_count}] Seller model failed: {exc.category}")
                 break
+            else:
+                self._record_usage(f"turn_{turn_count}_seller", "seller", self.seller_model)
 
             if seller_response is None or not str(seller_response).strip():
                 self.completed_turns = turn_count - 1
@@ -611,10 +639,13 @@ class Conversation:
             try:
                 buyer_response = self.buyer_model.get_chat_response(buyer_messages)
             except ModelCallError as exc:
+                self._record_usage(f"turn_{turn_count}_buyer", "buyer", self.buyer_model)
                 self.completed_turns = turn_count - 1
                 self._record_data_error(exc, stage=f"turn_{turn_count}_buyer", role="buyer")
                 print(f"\n[Turn {turn_count}] Buyer model failed: {exc.category}")
                 break
+            else:
+                self._record_usage(f"turn_{turn_count}_buyer", "buyer", self.buyer_model)
 
             if buyer_response is None or not str(buyer_response).strip():
                 self.completed_turns = turn_count - 1
@@ -674,6 +705,8 @@ class Conversation:
             "seller_price_offers": self.seller_price_offers,
             "price_extraction_events": self.price_extraction_events,
             "judge_events": self.judge_events,
+            "usage_events": self.usage_events,
+            "usage_summary": self.usage_summary(),
             "budget": self.budget,  # Include budget in the saved data
             "budget_scenario": self.budget_scenario,  # Include budget scenario name
             "completed_turns": self.completed_turns,  # Include the actual number of turns

--- a/LanguageModel.py
+++ b/LanguageModel.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 
@@ -99,19 +99,110 @@ def _validate_messages(messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
 class ModelCallError(RuntimeError):
     """Structured failure from a model provider call."""
 
-    def __init__(self, model: str, category: str, message: str, attempts: int = 0):
+    def __init__(
+        self,
+        model: str,
+        category: str,
+        message: str,
+        attempts: int = 0,
+        usage_events: Optional[List[Dict[str, object]]] = None,
+    ):
         self.model = model
         self.category = category
         self.attempts = attempts
+        self.usage_events = usage_events or []
         super().__init__(f"{category} error for {model} after {attempts} attempt(s): {message}")
 
     def to_dict(self) -> Dict[str, object]:
-        return {
+        payload = {
             "model": self.model,
             "category": self.category,
             "attempts": self.attempts,
             "message": str(self),
         }
+        if self.usage_events:
+            payload["usage_events"] = self.usage_events
+        return payload
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _number_or_none(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_number(*values: Any) -> Optional[float]:
+    for value in values:
+        number = _number_or_none(value)
+        if number is not None:
+            return number
+    return None
+
+
+def _token_value(*values: Any) -> Optional[int]:
+    number = _first_number(*values)
+    return int(number) if number is not None else None
+
+
+def extract_usage_metadata(
+    response: Any,
+    requested_model: str,
+    model: str,
+    attempt: int,
+) -> Dict[str, object]:
+    """Extract non-sensitive LiteLLM/provider usage metadata from a response."""
+    usage = _field(response, "usage", {}) or {}
+    hidden_params = _field(response, "_hidden_params", {}) or {}
+
+    prompt_tokens = _token_value(
+        _field(usage, "prompt_tokens"),
+        _field(usage, "input_tokens"),
+    )
+    completion_tokens = _token_value(
+        _field(usage, "completion_tokens"),
+        _field(usage, "output_tokens"),
+    )
+    total_tokens = _token_value(_field(usage, "total_tokens"))
+    if total_tokens is None and prompt_tokens is not None and completion_tokens is not None:
+        total_tokens = prompt_tokens + completion_tokens
+
+    estimated_cost_usd = _first_number(
+        _field(response, "response_cost"),
+        _field(response, "cost"),
+        _field(hidden_params, "response_cost"),
+        _field(hidden_params, "cost"),
+        _field(hidden_params, "litellm_response_cost"),
+    )
+
+    choices = _field(response, "choices", []) or []
+    first_choice = choices[0] if choices else None
+
+    return {
+        "requested_model": requested_model,
+        "model": model,
+        "response_model": _field(response, "model"),
+        "provider": _field(response, "provider") or _field(hidden_params, "custom_llm_provider"),
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "estimated_cost_usd": estimated_cost_usd,
+        "usage_available": any(
+            value is not None
+            for value in (prompt_tokens, completion_tokens, total_tokens, estimated_cost_usd)
+        ),
+        "attempt": attempt,
+        "finish_reason": _field(first_choice, "finish_reason"),
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
 
 
 def _status_code_from_exception(exc: Exception) -> Optional[int]:
@@ -223,6 +314,8 @@ class LanguageModel:
         self._max_retries = int(os.getenv("A2ANT_MAX_RETRIES", "5"))
         self.last_call_attempts = 0
         self.last_error_categories = []
+        self.last_usage_event = None
+        self.last_call_usage_events = []
         self._setup_credentials()
 
     def _setup_credentials(self) -> None:
@@ -250,6 +343,8 @@ class LanguageModel:
         retry_delay = 2.0
         self.last_call_attempts = 0
         self.last_error_categories = []
+        self.last_usage_event = None
+        self.last_call_usage_events = []
 
         for attempt in range(1, self._max_retries + 1):
             self.last_call_attempts = attempt
@@ -262,10 +357,21 @@ class LanguageModel:
                     temperature=temperature,
                     max_tokens=max_tokens,
                 )
-                if not response or not getattr(response, "choices", None):
+                choices = _field(response, "choices")
+                if not response or not choices:
                     raise ValueError("LiteLLM returned an empty response")
 
-                content = response.choices[0].message.content
+                usage_event = extract_usage_metadata(
+                    response=response,
+                    requested_model=self.requested_model_name,
+                    model=self.model_name,
+                    attempt=attempt,
+                )
+                self.last_usage_event = usage_event
+                self.last_call_usage_events.append(usage_event)
+
+                message = _field(choices[0], "message", {})
+                content = _field(message, "content")
                 if content is None:
                     raise ValueError("LiteLLM response message content is empty")
                 return content
@@ -286,6 +392,7 @@ class LanguageModel:
                         category=category,
                         message=str(exc),
                         attempts=attempt,
+                        usage_events=list(self.last_call_usage_events),
                     ) from exc
                 time.sleep(retry_delay)
                 retry_delay *= 2
@@ -294,7 +401,14 @@ class LanguageModel:
             category="transient",
             message="Retry loop exhausted without a response",
             attempts=self._max_retries,
+            usage_events=list(self.last_call_usage_events),
         )
+
+    def consume_usage_events(self) -> List[Dict[str, object]]:
+        events = list(self.last_call_usage_events)
+        self.last_call_usage_events = []
+        self.last_usage_event = None
+        return events
 
     def get_response(
         self,

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ python3 scripts/run_sweep.py --config configs/sweep_example.json --mode all --pa
 Live sweeps write a manifest under `logs/run_sessions/{run_id}/manifest.json`
 and per-pair logs under `logs/run_sessions/{run_id}/pairs/`. The manifest tracks
 the expected conversation cell count, completed valid JSON count, running pairs,
-failed pairs, and output directory. Resume logic counts only parseable result
-JSON files without `data_error` unless `--include-error-files` is explicitly
-provided.
+failed pairs, output directory, and provider usage totals when LiteLLM returns
+usage metadata. Resume logic counts only parseable result JSON files without
+`data_error` unless `--include-error-files` is explicitly provided.
 
 Provider key-limit, quota/billing, auth, invalid-model, and bad-request errors
 are treated as run-fatal. The current conversation is saved as evidence, the
@@ -155,6 +155,12 @@ Each result file contains the conversation history, extracted seller offers, neg
 
 Result files also include `price_extraction_events`, which record the summary-model extraction response, parsed price, parser source, unparsed cases, and rejected price mentions. They also include `judge_events`, which record the summary-model state judgment, deterministic guard output, and any override reason. Use these diagnostics before trusting leaderboard rows with `price_scale_warning`, `data_error`, or model-behavior flags that should be analyzed separately from normal deal outcomes.
 
+New result files also include `usage_events` and `usage_summary` with
+non-sensitive provider metadata such as model id, role, stage, token counts, and
+LiteLLM/OpenRouter estimated cost when available. Historical result files that
+lack these fields cannot be cost-audited from local artifacts alone; use the
+provider dashboard or billing export for those runs.
+
 Summarize a run:
 
 ```bash
@@ -178,6 +184,11 @@ model-behavior flags directly from result JSON files. By default, files marked
 runs. Clean-deal metrics exclude accepted rows with `out_of_budget`,
 `product_substitution`, or `fee_exclusion` so leaderboard rows are not silently
 contaminated by known model-behavior anomalies.
+
+Partial or provider-interrupted sweeps should be treated as diagnostic pilot
+artifacts, not publishable leaderboards. They are useful for debugging prompts,
+summary-model behavior, anomaly labels, and cost accounting, but final rankings
+should use comparable cells from a completed run.
 
 ## Project Structure
 

--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -278,6 +278,99 @@ def inspect_result_file(path, include_error_files=False):
     return info
 
 
+def _numeric(value):
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _empty_usage_bucket():
+    return {
+        "calls": 0,
+        "usage_available_calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "estimated_cost_usd": 0.0,
+    }
+
+
+def _add_usage_to_bucket(bucket, event):
+    bucket["calls"] += 1
+    if event.get("usage_available"):
+        bucket["usage_available_calls"] += 1
+
+    prompt_tokens = _numeric(event.get("prompt_tokens"))
+    completion_tokens = _numeric(event.get("completion_tokens"))
+    total_tokens = _numeric(event.get("total_tokens"))
+    if total_tokens is None and prompt_tokens is not None and completion_tokens is not None:
+        total_tokens = prompt_tokens + completion_tokens
+
+    for field, value in (
+        ("prompt_tokens", prompt_tokens),
+        ("completion_tokens", completion_tokens),
+        ("total_tokens", total_tokens),
+    ):
+        if value is not None:
+            bucket[field] += int(value)
+
+    cost = _numeric(event.get("estimated_cost_usd"))
+    if cost is not None:
+        bucket["estimated_cost_usd"] += cost
+
+
+def summarize_usage_events(events):
+    """Aggregate non-sensitive provider usage events."""
+    summary = _empty_usage_bucket()
+    summary["by_model"] = {}
+    summary["by_role"] = {}
+
+    for raw_event in events or []:
+        if not isinstance(raw_event, dict):
+            continue
+        _add_usage_to_bucket(summary, raw_event)
+
+        model = raw_event.get("model") or raw_event.get("requested_model") or "unknown"
+        role = raw_event.get("role") or "unknown"
+        _add_usage_to_bucket(summary["by_model"].setdefault(model, _empty_usage_bucket()), raw_event)
+        _add_usage_to_bucket(summary["by_role"].setdefault(role, _empty_usage_bucket()), raw_event)
+
+    summary["estimated_cost_usd"] = round(summary["estimated_cost_usd"], 8)
+    for group in (summary["by_model"], summary["by_role"]):
+        for bucket in group.values():
+            bucket["estimated_cost_usd"] = round(bucket["estimated_cost_usd"], 8)
+    return summary
+
+
+def aggregate_usage_from_results(result_dir, include_error_files=True):
+    """Aggregate usage events from parseable result JSON files."""
+    events = []
+    result_files = 0
+    files_with_usage = 0
+
+    for path in iter_result_files(result_dir):
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("data_error") and not include_error_files:
+            continue
+        result_files += 1
+
+        file_events = data.get("usage_events")
+        if isinstance(file_events, list) and file_events:
+            files_with_usage += 1
+            events.extend(file_events)
+
+    summary = summarize_usage_events(events)
+    summary["result_files"] = result_files
+    summary["files_with_usage"] = files_with_usage
+    return summary
+
+
 def count_valid_results(result_dir, product_id=None, include_error_files=False):
     return sum(
         1

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from experiment_utils import count_valid_results, load_products, parse_csv, safe_path_name
+from experiment_utils import aggregate_usage_from_results, count_valid_results, load_products, parse_csv, safe_path_name
 from LanguageModel import RUN_FATAL_EXIT_CODE
 
 
@@ -163,6 +163,10 @@ class SweepManifest:
                 self.payload["output_dir"],
                 include_error_files=False,
             )
+            self.payload["usage_summary"] = aggregate_usage_from_results(
+                self.payload["output_dir"],
+                include_error_files=True,
+            )
             self.write()
 
 
@@ -238,6 +242,7 @@ def make_session(plan, args, pairs, products_file, product_count, budgets, num_e
         "pair_count": len(pairs),
         "expected_conversation_cells": len(pairs) * product_count * len(budgets) * num_experiments,
         "completed_result_json_count": count_valid_results(output_dir, include_error_files=False),
+        "usage_summary": aggregate_usage_from_results(output_dir, include_error_files=True),
         "output_dir": output_dir,
         "parallel_workers": args.parallel_workers,
         "continue_on_error": args.continue_on_error,
@@ -380,6 +385,10 @@ def main():
             completed_result_json_count=count_valid_results(
                 args.output_dir or plan["output_dir"],
                 include_error_files=False,
+            ),
+            usage_summary=aggregate_usage_from_results(
+                args.output_dir or plan["output_dir"],
+                include_error_files=True,
             ),
         )
 

--- a/scripts/summarize_results.py
+++ b/scripts/summarize_results.py
@@ -11,7 +11,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from MarkAnomaly import PostDataProcessor
-from experiment_utils import parse_price
+from experiment_utils import parse_price, summarize_usage_events
 
 
 def iter_result_files(results_dir: Path):
@@ -177,6 +177,8 @@ def summarize(results_dir: Path, include_error_files: bool = False) -> Dict[str,
     total_files = 0
     analyzed_files = 0
     skipped_data_error = 0
+    usage_events: List[Dict[str, Any]] = []
+    files_with_usage = 0
 
     for path in iter_result_files(results_dir):
         with path.open("r", encoding="utf-8") as f:
@@ -186,6 +188,10 @@ def summarize(results_dir: Path, include_error_files: bool = False) -> Dict[str,
             skipped_data_error += 1
             continue
         analyzed_files += 1
+        file_usage_events = data.get("usage_events")
+        if isinstance(file_usage_events, list) and file_usage_events:
+            files_with_usage += 1
+            usage_events.extend(event for event in file_usage_events if isinstance(event, dict))
 
         models = data.get("models", {})
         seller = models.get("seller", "unknown")
@@ -235,6 +241,8 @@ def summarize(results_dir: Path, include_error_files: bool = False) -> Dict[str,
         "analyzed_files": analyzed_files,
         "skipped_data_error": skipped_data_error,
         "include_error_files": include_error_files,
+        "files_with_usage": files_with_usage,
+        "usage_summary": summarize_usage_events(usage_events),
         "pairs": pair_rows,
         "seller_leaderboard": seller_rows,
         "buyer_leaderboard": buyer_rows,

--- a/tests/test_conversation_judge.py
+++ b/tests/test_conversation_judge.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -192,12 +193,31 @@ class ConversationJudgeTest(unittest.TestCase):
             {"speaker": "Seller", "message": "I can do $225."},
             {"speaker": "Buyer", "message": "Deal at $225."},
         ]
+        conversation.usage_events = [
+            {
+                "stage": "buyer_intro",
+                "role": "buyer",
+                "model": "fake-buyer",
+                "prompt_tokens": 3,
+                "completion_tokens": 4,
+                "total_tokens": 7,
+                "estimated_cost_usd": 0.0007,
+                "usage_available": True,
+            }
+        ]
         conversation.evaluate_negotiation_state()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             conversation.save_conversation(tmp_dir)
             output = Path(tmp_dir) / "product_1_exp_0.json"
-            self.assertIn('"judge_events"', output.read_text(encoding="utf-8"))
+            data = output.read_text(encoding="utf-8")
+            self.assertIn('"judge_events"', data)
+            self.assertIn('"usage_events"', data)
+            self.assertIn('"usage_summary"', data)
+            payload = json.loads(data)
+            self.assertEqual(payload["usage_summary"]["calls"], 1)
+            self.assertEqual(payload["usage_summary"]["total_tokens"], 7)
+            self.assertEqual(payload["usage_summary"]["by_role"]["buyer"]["calls"], 1)
             self.assertEqual(list(Path(tmp_dir).glob("*.tmp.*")), [])
 
     def test_buyer_intro_failure_is_saved_as_data_error(self):

--- a/tests/test_experiment_utils.py
+++ b/tests/test_experiment_utils.py
@@ -8,6 +8,7 @@ from experiment_utils import (
     count_valid_results,
     extract_price_from_text,
     inspect_result_file,
+    aggregate_usage_from_results,
     next_experiment_number,
     looks_like_no_price,
     parse_int_csv,
@@ -16,6 +17,7 @@ from experiment_utils import (
     safe_path_name,
     select_budget_scenarios,
     select_products,
+    summarize_usage_events,
 )
 
 
@@ -91,6 +93,72 @@ class ExperimentUtilsTest(unittest.TestCase):
             self.assertEqual(count_valid_results(root, product_id=1, include_error_files=True), 2)
             self.assertEqual(next_experiment_number(valid_dir, product_id=1), 3)
             self.assertFalse(inspect_result_file(valid_dir / "product_1_exp_2.json")["valid"])
+
+    def test_summarize_usage_events_groups_by_model_and_role(self):
+        summary = summarize_usage_events(
+            [
+                {
+                    "model": "model-a",
+                    "role": "buyer",
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                    "estimated_cost_usd": 0.01,
+                    "usage_available": True,
+                },
+                {
+                    "model": "model-a",
+                    "role": "summary",
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                    "estimated_cost_usd": 0.002,
+                    "usage_available": True,
+                },
+            ]
+        )
+
+        self.assertEqual(summary["calls"], 2)
+        self.assertEqual(summary["prompt_tokens"], 13)
+        self.assertEqual(summary["completion_tokens"], 7)
+        self.assertEqual(summary["total_tokens"], 20)
+        self.assertEqual(summary["estimated_cost_usd"], 0.012)
+        self.assertEqual(summary["by_model"]["model-a"]["calls"], 2)
+        self.assertEqual(summary["by_role"]["buyer"]["total_tokens"], 15)
+
+    def test_aggregate_usage_from_results_includes_data_error_costs_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            result_dir = root / "seller_a" / "buyer_b" / "product_1" / "budget_mid"
+            result_dir.mkdir(parents=True)
+            result_payload = {
+                "product_id": 1,
+                "experiment_num": 0,
+                "conversation_history": [],
+                "data_error": True,
+                "usage_events": [
+                    {
+                        "model": "model-a",
+                        "role": "seller",
+                        "prompt_tokens": 4,
+                        "completion_tokens": 6,
+                        "estimated_cost_usd": 0.004,
+                        "usage_available": True,
+                    }
+                ],
+            }
+            (result_dir / "product_1_exp_0.json").write_text(json.dumps(result_payload), encoding="utf-8")
+
+            included = aggregate_usage_from_results(root)
+            excluded = aggregate_usage_from_results(root, include_error_files=False)
+
+            self.assertEqual(included["result_files"], 1)
+            self.assertEqual(included["files_with_usage"], 1)
+            self.assertEqual(included["calls"], 1)
+            self.assertEqual(included["total_tokens"], 10)
+            self.assertEqual(included["estimated_cost_usd"], 0.004)
+            self.assertEqual(excluded["result_files"], 0)
+            self.assertEqual(excluded["calls"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -12,13 +12,17 @@ class FakeProviderError(Exception):
         self.status_code = status_code
 
 
-def fake_response(content):
+def fake_response(content, usage=None, hidden_params=None):
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(content=content),
+                finish_reason="stop",
             )
-        ]
+        ],
+        usage=usage,
+        _hidden_params=hidden_params or {},
+        model="provider/model-response",
     )
 
 
@@ -74,6 +78,64 @@ class LanguageModelTest(unittest.TestCase):
 
         self.assertEqual(model.get_response("hello"), "ok")
         self.assertEqual(len(calls), 2)
+
+    def test_success_records_usage_metadata(self):
+        def respond(**_kwargs):
+            return fake_response(
+                "ok",
+                usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+                hidden_params={"response_cost": 0.00123, "custom_llm_provider": "openrouter"},
+            )
+
+        LanguageModel._LITELLM_COMPLETION = respond
+        model = ModelGate("local-test-model")
+        model._rate_limit_delay = 0
+
+        self.assertEqual(model.get_response("hello"), "ok")
+
+        self.assertEqual(model.last_usage_event["requested_model"], "local-test-model")
+        self.assertEqual(model.last_usage_event["model"], "local-test-model")
+        self.assertEqual(model.last_usage_event["response_model"], "provider/model-response")
+        self.assertEqual(model.last_usage_event["provider"], "openrouter")
+        self.assertEqual(model.last_usage_event["prompt_tokens"], 11)
+        self.assertEqual(model.last_usage_event["completion_tokens"], 7)
+        self.assertEqual(model.last_usage_event["total_tokens"], 18)
+        self.assertEqual(model.last_usage_event["estimated_cost_usd"], 0.00123)
+        self.assertTrue(model.last_usage_event["usage_available"])
+
+    def test_consume_usage_events_clears_last_call_events(self):
+        def respond(**_kwargs):
+            return fake_response("ok", usage={"prompt_tokens": 1, "completion_tokens": 2})
+
+        LanguageModel._LITELLM_COMPLETION = respond
+        model = ModelGate("local-test-model")
+        model._rate_limit_delay = 0
+
+        model.get_response("hello")
+        events = model.consume_usage_events()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["total_tokens"], 3)
+        self.assertEqual(model.last_call_usage_events, [])
+        self.assertIsNone(model.last_usage_event)
+
+    def test_success_accepts_dict_response_shape(self):
+        def respond(**_kwargs):
+            return {
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 3},
+                "_hidden_params": {"response_cost": 0.005},
+                "model": "dict-model-response",
+            }
+
+        LanguageModel._LITELLM_COMPLETION = respond
+        model = ModelGate("local-test-model")
+        model._rate_limit_delay = 0
+
+        self.assertEqual(model.get_response("hello"), "ok")
+        self.assertEqual(model.last_usage_event["response_model"], "dict-model-response")
+        self.assertEqual(model.last_usage_event["total_tokens"], 5)
+        self.assertEqual(model.last_usage_event["estimated_cost_usd"], 0.005)
 
 
 if __name__ == "__main__":

--- a/tests/test_summarize_results.py
+++ b/tests/test_summarize_results.py
@@ -32,6 +32,17 @@ class SummarizeResultsTest(unittest.TestCase):
                 "completed_turns": 4,
                 "negotiation_result": "accepted",
                 "data_error": False,
+                "usage_events": [
+                    {
+                        "model": "seller-a",
+                        "role": "seller",
+                        "prompt_tokens": 10,
+                        "completion_tokens": 8,
+                        "total_tokens": 18,
+                        "estimated_cost_usd": 0.01,
+                        "usage_available": True,
+                    }
+                ],
             }
             write_result(root, "seller_a/buyer_b/product_1/budget_mid/product_1_exp_0.json", base_payload)
             write_result(
@@ -45,6 +56,10 @@ class SummarizeResultsTest(unittest.TestCase):
             self.assertEqual(payload["total_files"], 2)
             self.assertEqual(payload["analyzed_files"], 1)
             self.assertEqual(payload["skipped_data_error"], 1)
+            self.assertEqual(payload["files_with_usage"], 1)
+            self.assertEqual(payload["usage_summary"]["calls"], 1)
+            self.assertEqual(payload["usage_summary"]["total_tokens"], 18)
+            self.assertEqual(payload["usage_summary"]["estimated_cost_usd"], 0.01)
             self.assertEqual(payload["risk_summary"]["out_of_budget"], 0)
             pair = payload["pairs"][0]
             self.assertEqual(pair["episodes"], 1)


### PR DESCRIPTION
Closes #17

## Summary
- Record non-sensitive LiteLLM/provider usage metadata for successful model responses.
- Persist per-conversation `usage_events` and aggregated `usage_summary` in result JSON files.
- Aggregate usage totals into sweep manifests and `scripts/summarize_results.py` outputs.
- Document partial/provider-interrupted sweeps as diagnostic pilot artifacts, not publishable leaderboards.

## Verification
- `python3 -m unittest tests.test_language_model tests.test_conversation_judge tests.test_experiment_utils tests.test_summarize_results`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 main.py --products-file dataset/products_mini.json --buyer-model openrouter/openai/gpt-4o-mini --seller-model openrouter/openai/gpt-4o-mini --summary-model openrouter/openai/gpt-4o-mini --budget-scenarios wholesale,mid,retail --product-limit 1 --dry-run`
- `python3 scripts/run_sweep.py --config configs/sweep_example.json --max-pairs 1 --product-limit 1 --dry-run`
- `python3 scripts/summarize_results.py --results-dir results/full_sweep_20260607_2002 --output-json /tmp/a2ant_usage_check/summary.json --output-js /tmp/a2ant_usage_check/summary.js --output-csv /tmp/a2ant_usage_check/pairs.csv`

## Notes
Existing partial-run artifacts without `usage_events` still cannot be precisely cost-audited from local files. The new fields make future runs auditable by run, model, role, and result file when provider usage metadata is available.
